### PR TITLE
fix for when 'main' isn't relative to 'base'

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,7 +335,7 @@ exports.wrapDir = function (base, opts) {
             if (!libname.match(/^\.\//)) libname = './' + libname;
             
             var pkgname = main && (
-                unext(main) === file || unext(main) === libname
+                unext(main) === unext(file) || unext(main) === libname
             ) ? '.' : libname;
             
             return exports.wrap(pkgname, {


### PR DESCRIPTION
Tried to do:

``` js
  var source = require("browserify").bundle({
    base: __dirname + "/lib",
    main: __dirname + "/lib/brain",
    name: "brain"
  });
```

But `main` wasn't mapped because it wasn't relative to the base. I think you intended to support this based on the code, but didn't remove the file extension when matching.
