### PR TITLE
fix watching of entries

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -215,12 +215,12 @@ Wrap.prototype.include = function (file, target, body) {
 };
 
 Wrap.prototype.reload = function (name) {
-    if (this.files[name]) {
+    if (this.files[name] !== undefined) {
         var file = this.files[name];
         delete this.files[name];
         this.require(name, { target : file.target });
     }
-    else if (this.entries[name]) {
+    else if (this.entries[name] !== undefined) {
         this.appends.splice(this.entries[name], 1);
         this.addEntry(name);
     }


### PR DESCRIPTION
when there is only 1 entry, `this.entries[file]` will be `0` and thus it will not jump into the `if()` statement since its falsy

i tried to patch the current watch-test but messed it up - so a test will come soon, have to sleep now :p
