### PR TITLE
Fixes for Internet Explorer 8

### DIFF
--- a/wrappers/prelude.js
+++ b/wrappers/prelude.js
@@ -91,7 +91,7 @@ require.resolve = (function () {
         function nodeModulesPathsSync (start) {
             var parts;
             if (start === '/') parts = [ '' ];
-            else parts = path.normalize(start).split(/\/+/);
+            else parts = path.normalize(start).split('/');
             
             var dirs = [];
             for (var i = parts.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Hi,

I have the misfortune of supporting IE8 in a project I'm using browsify for and came across a couple of bugs that were causing the browserified script to break on that browser.

Attached are two commits to fix these issues:
1. Array.reduce isn't supported on IE8. There was one use of this and while what it was doing was pretty natty, I don't see the need for it esp as it breaks older browsers and is probably a tad slower.  I could have used es5-shim, but think that the core browserify code shouldn't need this to function..
2. String.split doesn't work the same in IE and other browsers.  Specifically, passing String.split a RegExp will cause empty values to be stripped out of the resulting array in IE, but not in other browsers.  Changing the call to take a string rather than a RegExp fixes this, but potentially doesn't deal with double-slashes as well as before.  I'm choosing to ignore this but you could put in a small bit of de-double-slash code above this if you want to be as bullet-proof as before.

Thanks and keep up the good work - Browserify is a really good module to work with.
