### PR TITLE
Fix relative requires when using watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var exports = module.exports = function (opts) {
                 else if (curr.mtime !== prev.mtime) {
                     // modified
                     fs.unwatchFile(file);
-                    w.reload(file, opts);
+                    w.reload(file);
                     
                     _cache = null;
                 }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -202,23 +202,24 @@ Wrap.prototype.wrap = function (target, body) {
     ;
 };
 
-Wrap.prototype.include = function (file, target, body) {
+Wrap.prototype.include = function (file, target, body, root) {
     var synthetic = !file;
     if (!file) file = Math.floor(Math.random() * Math.pow(2,32)).toString(16);
     
     this.files[file] = {
         body : this.wrap(target, body),
         target : target,
-        synthetic : synthetic
+        synthetic : synthetic,
+        root : root
     };
     return this;
 };
 
-Wrap.prototype.reload = function (name, opts) {
+Wrap.prototype.reload = function (name) {
     if (this.files[name] !== undefined) {
         var file = this.files[name];
         delete this.files[name];
-        this.require(name, { target : file.target, root : opts.root });
+        this.require(name, { target : file.target, root : file.root });
     }
     else if (this.entries[name] !== undefined) {
         this.appends.splice(this.entries[name], 1);
@@ -351,13 +352,13 @@ Wrap.prototype.require = function (mfile, opts) {
             }
             
             self.include(pkgfile, makeTarget(pkgfile, opts.root), 
-                'module.exports = ' + JSON.stringify(pkg)
+                'module.exports = ' + JSON.stringify(pkg), opts.root
             );
         }
     }
     
     var body = self.readFile(file);
-    self.include(file, opts.target, body);
+    self.include(file, opts.target, body, opts.root);
     
     var required = detective.find(body);
     if (pkg.browserify && pkg.browserify.require) {


### PR DESCRIPTION
Browserify throws an exception when using relative requires that start with '../' with the watch option enabled, because require/makeTarget isn't aware of the root dir when reloading. This small patch passes the opts objects to Wrap.prototype.reload so it can pass opts.root to require/makeTarget.
