### PR TITLE
Use relative requires in tests.

### DIFF
--- a/test/field.js
+++ b/test/field.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var browserify = require('browserify');
+var browserify = require('../');
 var vm = require('vm');
 
 exports.fieldString = function () {

--- a/test/maxlisteners.js
+++ b/test/maxlisteners.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var EventEmitter = require('browserify/builtins/events').EventEmitter;
+var EventEmitter = require('../builtins/events').EventEmitter;
 
 exports.setMaxListener = function () {
     var ee = new EventEmitter;


### PR DESCRIPTION
Fixes to requires to be relative to make sure code is loaded from your development checkout.
