### PR TITLE
Browserify supports caching (yep, "strong" and "weak")!

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -407,7 +407,7 @@ Express, you can use the 'browserifyMount' local in your views.
 //This now happens in the Browserify middleware
 req.browserifyMount = (opts.mount || '/browserify.js') + '?' + self.modified.getTime();
 if(typeof res.local === "function")
-	res.local('browserifyMount', req.browserifyMount);
+    res.local('browserifyMount', req.browserifyMount);
 ````
 
 How about an example?
@@ -416,27 +416,27 @@ How about an example?
 var express = require('express');
 var server = express.createServer();
 server.use(require('browserify')({
-	mount: '/browserify.js',
+    mount: '/browserify.js',
     require : __dirname + '/js/foo.js',
     filter : require('uglify-js')
 }));
 
 server.get("/", function(req, res) {
-	res.render('index.jade', {layout: false});
+    res.render('index.jade', {layout: false});
 });
 server.listen(9797);
 ````
 
 Finally, in index.jade...
 
-	!!! strict
-	html(xmlns="http://www.w3.org/1999/xhtml")
-		head
-			meta(http-equiv="content-type", content="application/xhtml+xml; charset=UTF-8")
-			script(type="text/javascript", src=browserifyMount)
-			title= title
-		body
-			h1 This is a test!
+    !!! strict
+    html(xmlns="http://www.w3.org/1999/xhtml")
+        head
+            meta(http-equiv="content-type", content="application/xhtml+xml; charset=UTF-8")
+            script(type="text/javascript", src=browserifyMount)
+            title= title
+        body
+            h1 This is a test!
 
 protips
 =======

--- a/index.js
+++ b/index.js
@@ -105,41 +105,41 @@ var exports = module.exports = function (opts) {
         }
         listening = true;
         
-		//Populate the _cache even if we aren't getting the bundle on this request
-		if (!_cache) self.bundle();
-		
-		//Make mount point available to other middleware and views
-		req.browserifyMount = (opts.mount || '/browserify.js') + '?' + self.modified.getTime();
-		if(typeof res.local === "function")
-			res.local('browserifyMount', req.browserifyMount);
-		
-		var url = req.url.split('?');
+        //Populate the _cache even if we aren't getting the bundle on this request
+        if (!_cache) self.bundle();
+        
+        //Make mount point available to other middleware and views
+        req.browserifyMount = (opts.mount || '/browserify.js') + '?' + self.modified.getTime();
+        if(typeof res.local === "function")
+            res.local('browserifyMount', req.browserifyMount);
+        
+        var url = req.url.split('?');
         if (url[0] === (opts.mount || '/browserify.js')) {
-			res.setHeader('Last-Modified', self.modified.toUTCString());
-			res.setHeader('Content-Type', 'text/javascript');
-			/* Date header not needed, but included in case browsers get mad about long Expire dates?
-			What's an extra couple bytes anyway?  Besides, it's being cached, so it's very minimal
-			overhead... go with it. */
-			res.setHeader('Date', new Date().toUTCString() );
-			/* Add Expires header only if the query parameter is set to the last modified date.
-			This is important since the server may elect NOT to use "URL fingerprinting" and browsers
-			end up caching the file indefinitely. */
-			if(url[1] != undefined && url[1] == self.modified.getTime() )
-			{
-				var d = new Date();
-				d.setFullYear(d.getFullYear() + 1);
-				res.setHeader('Expires', d.toUTCString() );
-				res.setHeader('Cache-Control', 'public, max-age=31536000'); //31536000 = 365 days * 24 * 60 * 60
-			}
-			
-			if(new Date(req.headers["if-modified-since"]).toUTCString() == self.modified.toUTCString() ) {
-				res.statusCode = 304;
-				res.end();
-			}
-			else {
-				res.statusCode = 200;
-				res.end(_cache);
-			}
+            res.setHeader('Last-Modified', self.modified.toUTCString());
+            res.setHeader('Content-Type', 'text/javascript');
+            /* Date header not needed, but included in case browsers get mad about long Expire dates?
+            What's an extra couple bytes anyway?  Besides, it's being cached, so it's very minimal
+            overhead... go with it. */
+            res.setHeader('Date', new Date().toUTCString() );
+            /* Add Expires header only if the query parameter is set to the last modified date.
+            This is important since the server may elect NOT to use "URL fingerprinting" and browsers
+            end up caching the file indefinitely. */
+            if(url[1] != undefined && url[1] == self.modified.getTime() )
+            {
+                var d = new Date();
+                d.setFullYear(d.getFullYear() + 1);
+                res.setHeader('Expires', d.toUTCString() );
+                res.setHeader('Cache-Control', 'public, max-age=31536000'); //31536000 = 365 days * 24 * 60 * 60
+            }
+            
+            if(new Date(req.headers["if-modified-since"]).toUTCString() == self.modified.toUTCString() ) {
+                res.statusCode = 304;
+                res.end();
+            }
+            else {
+                res.statusCode = 200;
+                res.end(_cache);
+            }
         }
         else next()
     };


### PR DESCRIPTION
Browserify now supports browser caching, both "strong" and "weak".

"Last-Modified" and "If-Modified-Since" are "weak" caching.  If the "If-Modified-Since" header is set, then Browserify can send 304 Not Modified, if appropriate, which saves bandwidth.

"Expires" or "Cache-Control: max-age" are "strong" caching.  The browser can simply pull from its own cache in certain cases to save an entire HTTP request.  In the client HTML, if the Browserify URL contains a query parameter that exactly matches the last modified date of the bundle, "strong" caching headers will be set.  This allows a user to easily implement URL fingerprinting by simply appending the last modified date of the Browserify bundle (b.modified) to the mount URL.  The full Browserify mount URL (including the needed query parameter) is made available via req.browserifyMount.  Finally, if Express is being utilitzed, the 'browserifyMount' local is available to views via res.locals(...).

Tested on Chrome 13 and IE 8, Node 0.4.11.
See http://code.google.com/speed/page-speed/docs/caching.html for more details.
