### PR TITLE
Mysterious fix for requires outside of entry root

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -130,7 +130,7 @@ Wrap.prototype.addEntry = function (file, opts) {
     }
     
     required.strings.forEach(function (r) {
-        var x = r.match(/^(\.\.?)?\//) ? path.resolve(opts.root, r) : r;
+        var x = r.match(/^(\.\.?)?\//) ? path.resolve(dir, r) : r;
         self.require(x, { root : opts.root });
     });
     


### PR DESCRIPTION
OK, this one takes some explanation.

I have files laid out like so:

```
In /Users/dkastner/proj:
./bar/application.js
./bar/bar.js
./foo/foo.js
```

Here are the file contents:

```
// bar/application.js
var bar = require('./bar'),
    foo = require('../foo/foo');

bar();
foo();

// bar/bar.js
module.exports = function() { console.log('bar'); };

// foo/foo.js
module.exports = function() { console.log('this is foo'); };
```

When I run `browserify -e bar/application.js` from the project root I get an error that it can't find /Users/dkastner/proj/bar/bar/bar in /Users/dkastner/proj.

It still works fine if I comment out the require('../foo/foo') line in application.js, cd into bar, then run `browserify -e application.js`. However, the require('../foo/foo') does not work because foo is outside the root of where the entry point is located.

The fix I've posted was one that I just tried for the fun of it after dumping the dir and opts.root variables at runtime that were in Wrap#addEntry(). The tests still pass as well as when run without the fix, so I'm thinking this fix is fine, I just don't fully understand the code and was hoping you had some insight.
