### PR TITLE
npm package: only import usefull properties (main & browserify) to reduce

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -368,9 +368,9 @@ Wrap.prototype.require = function (mfile, opts) {
             var pkgBody = fs.readFileSync(pkgfile, 'utf8');
             try {
                 var npmpkg = JSON.parse(pkgBody);
-                if (npmpkg.main)
+                if (npmpkg.main !== undefined)
                   pkg.main = npmpkg.main;
-                if (npmpkg.browserify)
+                if (npmpkg.browserify !== undefined)
                   pkg.browserify = npmpkg.browserify;
             }
             catch (err) {


### PR DESCRIPTION
npm package: only import usefull properties (main & browserify) to reduce the bundled code size
