### PR TITLE
Adds .js to the script tag in the readme.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ var bundle = require('browserify')(__dirname + '/entry.js');
 app.use(bundle);
 ````
 
-Then just throw a `<script src="/browserify"></script>` into your HTML!
+Then just throw a `<script src="/browserify.js"></script>` into your HTML!
 
 using the API
 -------------


### PR DESCRIPTION
I was really confused by the readme, so I thought I could update this to add a .js so others wouldn't be confused when using the middleware.
