### PR TITLE
Fix loading toplevel directory from subdir in prelude

### DIFF
--- a/wrappers/prelude.js
+++ b/wrappers/prelude.js
@@ -51,8 +51,8 @@ require.resolve = (function () {
         }
         
         function loadAsDirectorySync (x) {
-            x = x.replace(/\/+$/, '');
-            var pkgfile = x + '/package.json';
+            var base = x.replace(/\/+$/, '');
+            var pkgfile = base + '/package.json';
             if (require.modules[pkgfile]) {
                 var pkg = require.modules[pkgfile]();
                 var b = pkg.browserify;
@@ -70,7 +70,7 @@ require.resolve = (function () {
                 }
             }
             
-            return loadAsFileSync(x + '/index');
+            return loadAsFileSync(base + '/index');
         }
         
         function loadNodeModulesSync (x, start) {


### PR DESCRIPTION
Consider the following package structure:
- package.json: <pre>{   "name":"testpkg",
  "main":"./index.js",
  "browserify":"./browser.js"
  }</pre>
- index.js: <pre>exports.stuff = 'for node';</pre>
- browser.js: <pre>exports.stuff = 'for browser';
  window.onload = function() {
  alert('code loaded, it works!');
  }</pre>
- entry.js: <pre>require('./subdir/require-super');</pre>
- subdir/require-super.js: <pre>require('../');</pre>

When running the browsified version of entry.js in a browser, the following error is thrown:

<pre>
Uncaught Error: Cannot find module '../'
</pre>


The loadAsDirectory function of the prelude script prepended to browserified modules strips off trailing slashes before concatenating the argument with '/package.js' and '/index'. If the argument is a single slash, i.e. a path pointing to the root directory, it should be preserved when passing to path.resolve subsequently.

Fix this problem by stripping off trailing slashes only for package/index lookup.
