### PR TITLE
register extensions given in opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,12 @@ var exports = module.exports = function (entryFile, opts) {
         })
     ;
     
+    if (opts.extensions) {
+        Object.keys(opts.extensions).forEach(function (ext) {
+            w.register(ext, opts.extensions[ext]);
+        });
+    }
+
     if (opts.watch) {
         var pending = {};
         


### PR DESCRIPTION
this also fixes the bug that it's impossible to register extensions when opts.watch is true
