### PR TITLE
fix relative file target to use deepest node_modules directory

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -289,7 +289,7 @@ function makeTarget (file, root) {
         return file.slice(base.length);
     }
     else if (file.match(/\/node_modules\/.+/)) {
-        return path.normalize(file.match(/(\/node_modules\/.+)/)[1]);
+        return path.normalize(file.match(/.*(\/node_modules\/.+)/)[1]);
     }
     else {
         throw new Error('Can only load non-root modules'


### PR DESCRIPTION
In the case of nested node_modules where the file root is not just a prefix of the other path, browserify will calculate the wrong relative path for the module target. It properly includes the module source but then cannot find the module in the browser.

For example:

arguments to /lib/wrap.js/makeTarget:
file: `/projects/marketing/node_modules/derby-examples/node_modules/derby/lib/derby.browser.js`
root: `/projects/marketing/node_modules/derby-examples/chat/lib/chat`
returns: `/node_modules/derby-examples/node_modules/derby/lib/derby.browser.js`

when it should return
 `/node_modules/derby/lib/derby.browser.js`

Instead of starting the target path after the first node_modules directory, using the deepest node_modules directory fixes the issue.
