### PR TITLE
Fix for command line plugin (#135)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var resolve = require('resolve');
 
 var rebased_require = function(id) {
-    var resolved = resolve.sync(plugin, {basedir : process.cwd()});
+    var resolved = resolve.sync(id, {basedir : process.cwd()});
     return require(resolved);
 };
 


### PR DESCRIPTION
Here is a fix for #135.

It's actually done by wrapping the require call for into a require function rebased in the curent work directory.

Please merge if Ok.
