### PR TITLE
Add globals lazily for all modules

### DIFF
--- a/builtins/assert.js
+++ b/builtins/assert.js
@@ -1,6 +1,5 @@
 // UTILITY
 var util = require('util');
-var Buffer = require("buffer").Buffer;
 var pSlice = Array.prototype.slice;
 
 // 1. The assert module provides functions that throw

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -13,12 +13,12 @@ var nub = require('nub');
 module.exports = function (opts) {
     return new Wrap(opts);
 };
- 
+
 function Wrap (opts) {
     if (opts.cache === undefined && process.env.HOME !== undefined) {
         opts.cache = true;
     }
-    
+
     if (opts.cache) {
         if (typeof opts.cache === 'boolean') {
             var file = process.env.HOME + '/.config/browserify/cache.json';
@@ -31,24 +31,30 @@ function Wrap (opts) {
     else {
         this.detective = detective;
     }
-    
+
     this.files = {};
     this.filters = [];
     this.postFilters = [];
     this.preFilters = [];
     this.aliases = {};
     this._checkedPackages = {};
-    
+
     this.ignoring = {};
     this.extensions = [ '.js' ];
-    
+
     this.prepends = [ wrappers.prelude, wrappers.process ];
-    this.appends = []
+    this.appends = [];
     this.entries = {};
     this.debug = opts.debug;
-    
+
+    this.globals = {
+        buffer: /\bBuffer\b/
+    };
+
     this.require([ 'path' ]);
 }
+
+
 
 Wrap.prototype = new EventEmitter;
 
@@ -65,12 +71,12 @@ Wrap.prototype.append = function (src) {
 Wrap.prototype.ignore = function (files) {
     if (!files) files = [];
     if (!Array.isArray(files)) files = [ files ];
-    
+
     this.ignoring = files.reduce(function (acc,x) {
         acc[x] = true;
         return acc;
     }, this.ignoring);
-    
+
     return this;
 };
 
@@ -84,7 +90,7 @@ Wrap.prototype.register = function (ext, fn) {
         fn = ext.wrapper;
         ext = ext.extension;
     }
-    
+
     if (ext === 'post') {
         this.postFilters.push(fn);
     }
@@ -108,13 +114,13 @@ Wrap.prototype.register = function (ext, fn) {
 
 Wrap.prototype.readFile = function (file) {
     var self = this;
-    
+
     var body = fs.readFileSync(file, 'utf8').replace(/^#![^\n]*\n/, '');
-    
+
     self.filters.forEach(function (fn) {
         body = fn.call(self, body, file);
     });
-    
+
     return body;
 };
 
@@ -126,9 +132,11 @@ Wrap.prototype.alias = function (to, from) {
 Wrap.prototype.addEntry = function (file, opts) {
     var self = this;
     if (!opts) opts = {};
-    
+
     var body = opts.body || self.readFile(file);
-    
+
+    self.supplyGlobals(body);
+
     try {
         var required = self.detective.find(body);
     }
@@ -138,27 +146,27 @@ Wrap.prototype.addEntry = function (file, opts) {
         });
         return self;
     }
-    
+
     if (required.expressions.length) {
         console.error('Expressions in require() statements:');
         required.expressions.forEach(function (ex) {
             console.error('    require(' + ex + ')');
         });
     }
-    
+
     var dir = path.dirname(path.resolve(process.cwd(), file));
     if (!opts.root) {
         opts.root = commondir(dir, required.strings.concat(file));
     }
     file = path.resolve(process.cwd(), file);
-    
+
     required.strings.forEach(function (r) {
         var x = r.match(/^(\.\.?)?\//) ? path.resolve(opts.root, r) : r;
         self.require(x, { root : opts.root });
     });
-    
+
     this.entries[file] = this.appends.length;
-    
+
     var target = opts.target || file.slice(dir.length);
     this.append((self.debug ? wrappers.entry_debug : wrappers.entry)
         .replace(/\$__filename/g, function () {
@@ -171,13 +179,37 @@ Wrap.prototype.addEntry = function (file, opts) {
             ;
         })
     );
-    
+
     return this;
 };
 
+// Check for globals so that we can supply them lazily to reduce file size
+Wrap.prototype.supplyGlobals = function (body) {
+    var self = this;
+
+    for (var name in self.globals) {
+        var pattern = self.globals[name];
+
+        if (pattern.found) {
+            continue;
+        }
+
+        if (pattern.test(body)) {
+            pattern.found = true;
+
+            self.require(name);
+
+            if (wrappers[name]) {
+                self.appends.push(wrappers[name]);
+            }
+        }
+
+    }
+}
+
 Wrap.prototype.bundle = function () {
     var self = this;
-    
+
     for (var i = 0; i < self.prepends.length; i++) {
         var p = self.prepends[i];
         if (p === wrappers.prelude) {
@@ -187,11 +219,11 @@ Wrap.prototype.bundle = function () {
             break;
         }
     }
-    
+
     this.preFilters.forEach((function (fn) {
         fn.call(this, this);
     }).bind(this));
-    
+
     var src = []
         .concat(this.prepends)
         .concat(Object.keys(self.files).map(function (name) {
@@ -202,7 +234,7 @@ Wrap.prototype.bundle = function () {
             if (!to.match(/^(\.\.?)?\//)) {
                 to = '/node_modules/' + to;
             }
-            
+
             return wrappers.alias
                 .replace(/\$from/, function () {
                     return JSON.stringify(from);
@@ -215,11 +247,11 @@ Wrap.prototype.bundle = function () {
         .concat(this.appends)
         .join('\n')
     ;
-    
+
     this.postFilters.forEach((function (fn) {
         src = fn.call(this, src);
     }).bind(this));
-    
+
     return src;
 };
 
@@ -241,7 +273,7 @@ Wrap.prototype.wrap = function (target, body) {
 Wrap.prototype.include = function (file, target, body, root) {
     var synthetic = !file;
     if (!file) file = Math.floor(Math.random() * Math.pow(2,32)).toString(16);
-    
+
     this.files[file] = {
         body : this.wrap(target, body),
         target : target,
@@ -265,7 +297,7 @@ Wrap.prototype.reload = function (name) {
         catch (e) {
             // Return item back to list
             this.appends.splice(this.entries[name], 0, items[0]);
-            
+
             // Rethrow error
             throw e;
         }
@@ -277,7 +309,7 @@ function makeTarget (file, root) {
     var base = path.resolve(__dirname, '..');
     var nm = base + '/node_modules/';
     var s = file.slice(0, nm.length);
-    
+
     if (isPrefixOf(root + '/', file)) {
         return path.normalize('/' + file.slice(root.length + 1));
     }
@@ -300,15 +332,15 @@ function makeTarget (file, root) {
 
 Wrap.prototype.requireMultiple = function (startFiles) {
     var self = this;
-    
+
     if (!startFiles) startFiles = []
     else if (!Array.isArray(startFiles)) {
         startFiles = [ startFiles ];
     }
-    
+
     startFiles.forEach(function include (file) {
         var dir = process.cwd();
-        
+
         if (typeof file === 'object') {
             Object.keys(file).forEach(function (key) {
                 self.alias(key, file[key]);
@@ -316,7 +348,7 @@ Wrap.prototype.requireMultiple = function (startFiles) {
             });
             return;
         }
-        
+
         if (resolve.isCore(file)) {
             var res = file;
         }
@@ -327,10 +359,10 @@ Wrap.prototype.requireMultiple = function (startFiles) {
         else {
             var res = file;
         }
-        
+
         self.require(res, { basedir : dir, root : dir });
     });
-    
+
     return self;
 };
 
@@ -338,19 +370,19 @@ Wrap.prototype.require = function (mfile, opts) {
     var self = this;
     if (!opts) opts = {};
     if (!opts.basedir) opts.basedir = process.cwd();
-    
+
     if (typeof mfile === 'object') {
         return self.requireMultiple(mfile, opts);
     }
-    
+
     if (self.ignoring[mfile]) return self;
     if (self.aliases[mfile]) return self;
-    
+
     var pkg = {};
     if (resolve.isCore(mfile)) {
         var file = path.resolve(__dirname, '../builtins/' + mfile + '.js');
         opts.target = opts.target || mfile;
-        
+
         if (!path.existsSync(file)) {
             try {
                 require.resolve(mfile + '-browserify');
@@ -381,20 +413,20 @@ Wrap.prototype.require = function (mfile, opts) {
             );
         }
     }
-    
+
     opts.basedir = path.dirname(file);
-    
+
     if (!opts.root && mfile.match(/^\//)) {
         opts.root = opts.basedir;
     }
-    
+
     if (!opts.target) {
         opts.target = makeTarget(file, opts.root);
     }
-     
+
     if (self.ignoring[opts.target]) return self;
     if (self.has(file, opts.target)) return self;
-    
+
     var pkgfile = opts.basedir + '/package.json';
     if (!mfile.match(/^(\.\.?)?\//)) {
         try {
@@ -404,7 +436,7 @@ Wrap.prototype.require = function (mfile, opts) {
         }
         catch (err) {}
     }
-     
+
     if (pkgfile && !self._checkedPackages[pkgfile]) {
         self._checkedPackages[pkgfile] = true;
         if (path.existsSync(pkgfile)) {
@@ -421,16 +453,19 @@ Wrap.prototype.require = function (mfile, opts) {
             catch (err) {
                 // ignore broken package.jsons just like node
             }
-            
-            self.include(pkgfile, makeTarget(pkgfile, opts.root), 
+
+            self.include(pkgfile, makeTarget(pkgfile, opts.root),
                 'module.exports = ' + JSON.stringify(pkg), opts.root
             );
         }
     }
-    
+
     var body = opts.body || self.readFile(file);
+
+    self.supplyGlobals(body);
+
     self.include(file, opts.target, body, opts.root);
-    
+
     try {
         var required = self.detective.find(body);
     }
@@ -440,24 +475,24 @@ Wrap.prototype.require = function (mfile, opts) {
         });
         return self;
     }
-    
+
     if (pkg.browserify && pkg.browserify.require) {
         required.strings = required.strings.concat(
             pkg.browserify.require
         );
     }
-    
+
     if (required.expressions.length) {
         console.error('Expressions in require() statements:');
         required.expressions.forEach(function (ex) {
             console.error('    require(' + ex + ')');
         });
     }
-    
+
     nub(required.strings).forEach(function (req) {
         self.require(req, { basedir : opts.basedir, root : opts.root })
     });
-    
+
     return self;
 };
 
@@ -467,7 +502,7 @@ function isPrefixOf (x, y) {
 
 Wrap.prototype.has = function (file, target) {
     if (this.files[file]) return true;
-    
+
     var filenames = Object.keys(this.files);
     for (var i = 0; i < filenames.length; i++) {
         var f = this.files[filenames[i]];

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,0 +1,29 @@
+var browserify = require('../');
+var vm = require('vm');
+var test = require('tap').test;
+
+test('globals', function (t) {
+    t.plan(1);
+
+    var src = browserify.bundle({
+        require: __dirname + '/globals/main.js'
+    });
+    var c = {};
+
+    vm.runInNewContext(src, c);
+
+    t.deepEqual(
+        Object.keys(c.require.modules).sort(),
+        [
+            'assert',
+            'buffer',
+            'buffer_ieee754',
+            'events',
+            'path',
+            'util',
+            '/main.js',
+        ].sort()
+    );
+
+    t.end();
+});

--- a/test/globals/main.js
+++ b/test/globals/main.js
@@ -1,0 +1,1 @@
+new Buffer(0);

--- a/wrappers/buffer.js
+++ b/wrappers/buffer.js
@@ -1,0 +1,4 @@
+// Buffer is a Node.js global, so expose it here outside of the modules
+if (!this.Buffer) {
+  Buffer = require('buffer').Buffer;
+}


### PR DESCRIPTION
Since `Buffer` is a global in Node.js, it would be nice if we supported that without having to modify the existing modules.

This change enables that, but does it lazily, so it is only exposed if used (to keep the output size down for those who don't need it).
