### PR TITLE
Fix bug in cmd.js that stopped plugins from working

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -97,7 +97,7 @@ if (argv.noprelude || argv.prelude === false) {
 if (argv.ignore) bundle.ignore(argv.ignore);
 
 ([].concat(argv.plugin || [])).forEach(function (plugin) {
-    var resolved = resolve.sync(id, { basedir : process.cwd() });
+    var resolved = resolve.sync(plugin, { basedir : process.cwd() });
     bundle.use(require(resolved));
 });
 


### PR DESCRIPTION
The line I changed was throwing an error because `id` was never defined. It seemed like it should have been `plugin` instead, and that does the trick.

However, I don't know a ton about the project source, so let me know if it shouldn't be that way for some reason.
