### PR TITLE
fixed entry and require options priority

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,17 +115,6 @@ var exports = module.exports = function (entryFile, opts) {
     
     w.ignore(opts.ignore || []);
     
-    if (opts.entry) {
-        if (Array.isArray(opts.entry)) {
-            opts.entry.forEach(function (e) {
-                w.addEntry(e);
-            });
-        }
-        else {
-            w.addEntry(opts.entry);
-        }
-    }
-    
     if (opts.require) {
         if (Array.isArray(opts.require)) {
             opts.require.forEach(function (r) {
@@ -162,6 +151,17 @@ var exports = module.exports = function (entryFile, opts) {
                 ;
             }
             w.require(opts.require, params);
+        }
+    }
+
+    if (opts.entry) {
+        if (Array.isArray(opts.entry)) {
+            opts.entry.forEach(function (e) {
+                w.addEntry(e);
+            });
+        }
+        else {
+            w.addEntry(opts.entry);
         }
     }
     


### PR DESCRIPTION
This fixes missing alias if using:

```
browserify.bundle({
    require : {alias:"real"},
    entry: 'file'
})
```
