### PR TITLE
Change module caching behavior in prelude.js

### DIFF
--- a/wrappers/prelude.js
+++ b/wrappers/prelude.js
@@ -10,6 +10,7 @@ var require = function (file, cwd) {
 
 require.paths = [];
 require.modules = {};
+require.cache = {};
 require.extensions = $extensions;
 
 require._core = {
@@ -119,7 +120,7 @@ require.alias = function (from, to) {
     
     var keys = (Object.keys || function (obj) {
         var res = [];
-        for (var key in obj) res.push(key)
+        for (var key in obj) res.push(key);
         return res;
     })(require.modules);
     
@@ -149,17 +150,17 @@ require.alias = function (from, to) {
         ;
         
         var require_ = function (file) {
-            return require(file, dirname)
+            return require(file, dirname);
         };
         require_.resolve = function (name) {
             return require.resolve(name, dirname);
         };
         require_.modules = require.modules;
         require_.define = require.define;
+        require_.cache = require.cache;
         var module_ = { exports : {} };
         
         require.modules[filename] = function () {
-            require.modules[filename]._cached = module_.exports;
             fn.call(
                 module_.exports,
                 require_,
@@ -169,7 +170,7 @@ require.alias = function (from, to) {
                 filename,
                 process
             );
-            require.modules[filename]._cached = module_.exports;
+            require.cache[filename] = module_.exports;
             return module_.exports;
         };
     };


### PR DESCRIPTION
I noticed that browserify manages the module caching slightly different compared to nodejs. nodejs provides a `cache`-object attached to `require()` as described [here](http://nodejs.org/docs/latest/api/globals.html#globals_require_cache). Thus a module can decide to reload another module.

In order to write modules that run in both environments browserify should do it like node.

As you can see in the attached code it's not necessary to change a lot. Unfortunately I couldn't find a place to write tests for it, but it seems like it doesn't break the old tests.
