### PR TITLE
Change module caching behavior in prelude.js (fixed)

### DIFF
--- a/test/require_cache.js
+++ b/test/require_cache.js
@@ -5,7 +5,7 @@ var browserify = require('../');
 var test = require('tap').test;
 
 test('require.cache', function (t) {
-    t.plan(2);
+    t.plan(3);
     
     var src = browserify().require('seq').bundle();
     var c = {};
@@ -14,5 +14,7 @@ test('require.cache', function (t) {
     t.equal(c.require.cache[seqPath], undefined);
     
     var seq = c.require('seq');
-    t.equal(seq, c.require.cache[seqPath]);
+    t.equal(seq, c.require.cache[seqPath].exports);
+    var seqCached = c.require('seq');   // check if require() uses the cache
+    t.equal(seq, seqCached);
 });

--- a/wrappers/prelude.js
+++ b/wrappers/prelude.js
@@ -4,7 +4,8 @@ var require = function (file, cwd) {
     if (!mod) throw new Error(
         'Failed to resolve module ' + file + ', tried ' + resolved
     );
-    var res = mod._cached ? mod._cached : mod();
+    var cached = require.cache[resolved];
+    var res = cached? cached.exports : mod();
     return res;
 }
 
@@ -161,6 +162,7 @@ require.alias = function (from, to) {
         var module_ = { exports : {} };
         
         require.modules[filename] = function () {
+            require.cache[filename] = module_;
             fn.call(
                 module_.exports,
                 require_,
@@ -170,7 +172,6 @@ require.alias = function (from, to) {
                 filename,
                 process
             );
-            require.cache[filename] = module_.exports;
             return module_.exports;
         };
     };


### PR DESCRIPTION
This issue is an amendment to #180.

I've forgotten to add the line that loads the module from cache if present. Furthermore I'm caching the module now instead of module.exports. _This_ is actually the way nodejs does it ;).

Tests have been adjusted.
