### PR TITLE
Use setImmediate for process.nextTick

### DIFF
--- a/builtins/__browserify_process.js
+++ b/builtins/__browserify_process.js
@@ -1,12 +1,18 @@
 var process = module.exports = {};
 
 process.nextTick = (function () {
-    var queue = [];
+    var canSetImmediate = typeof window !== 'undefined'
+        && window.setImmediate;
     var canPost = typeof window !== 'undefined'
         && window.postMessage && window.addEventListener
     ;
-    
+
+    if (canSetImmediate) {
+        return window.setImmediate;
+    }
+
     if (canPost) {
+        var queue = [];
         window.addEventListener('message', function (ev) {
             if (ev.source === window && ev.data === 'browserify-tick') {
                 ev.stopPropagation();
@@ -16,13 +22,13 @@ process.nextTick = (function () {
                 }
             }
         }, true);
-    }
 
         return function nextTick(fn) {
             queue.push(fn);
             window.postMessage('browserify-tick', '*');
         };
     }
+
     return function nextTick(fn) {
         setTimeout(fn, 0);
     };


### PR DESCRIPTION
We're using Browserify to write a Windows 8 Metro app in HTML5/JS, and it'd be cool if browserify used the native `setImmediate` instead of the `postMessage` tricksiness.
