### PR TITLE
Fixed race condition in watch mode

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -24,6 +24,25 @@ function reg (w, opts, body, file) {
         }
     };
     var pending = null;
+    var bundle = function () {
+        if (pending) return;
+        pending = setTimeout(function () {
+            pending = null;
+            // modified
+            if (w[type][file]) {
+                w.reload(file);
+            }
+            else if (type === 'entries') {
+                w.addEntry(file);
+            }
+            else if (type === 'files') {
+                w.require(file);
+            }
+            
+            w._cache = null;
+            w.emit('bundle');
+        }, 100);
+    };
     
     var watcher = function (event, filename) {
         exists(file, function (ex) {
@@ -39,27 +58,12 @@ function reg (w, opts, body, file) {
                 w._cache = null;
             }
             else if (event === 'change') {
-                if (pending) return;
-                pending = setTimeout(function () {
-                    pending = null;
-                    // modified
-                    if (w[type][file]) {
-                        w.reload(file);
-                    }
-                    else if (type === 'entries') {
-                        w.addEntry(file);
-                    }
-                    else if (type === 'files') {
-                        w.require(file);
-                    }
-                    
-                    w._cache = null;
-                    w.emit('bundle');
-                }, 100);
+                bundle();
             }
             else if (event === 'rename') {
                 w.watches[file].close();
                 process.nextTick(watch);
+                bundle();
             }
         });
     };

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -183,10 +183,11 @@ Wrap.prototype.addEntry = function (file_, opts) {
     if (!opts) opts = {};
     var file = path.resolve(opts.dirname || process.cwd(), file_);
     
-    var body = opts.body || self.readFile(file);
+    var entry = this.entries[file] = {};
+    // entry must be set before readFile for the watch
+    var body = entry.body = opts.body || self.readFile(file);
     if (body === undefined) return self;
     
-    var entry = this.entries[file] = { body : body };
     if (opts.target) entry.target = opts.target;
     
     try {
@@ -481,14 +482,16 @@ Wrap.prototype.require = function (mfile, opts) {
             };
         }
     }
-    
-    var body = opts.body || self.readFile(opts.file);
-    if (body === undefined) return self;
-    
+
     var entry = self.files[opts.file] = {
-        body : body,
         target : opts.target
     };
+    // entry must be set before readFile for the watch
+    var body = entry.body = opts.body || self.readFile(opts.file);
+    if (body === undefined) {
+        delete self.files[opts.file];
+        return self;
+    }
     
     try {
         var required = self.detective.find(body);


### PR DESCRIPTION
This pull request fixes the issues #217 and #166.
I fixed a race condition where the watch check if the file in files or entries before it is set in the array, and I force to reload renamed files.
