### PR TITLE
Only bundle when the modification time changed

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -12,17 +12,32 @@ function reg (w, opts, body, file) {
     if (w.watches[file]) return body;
     
     var type = w.files[file] ? 'files' : 'entries';
+    var mtime = null;
     
     var watch = function () {
         if (w.files[file] && w.files[file].synthetic) return;
         
-        if (typeof opts === 'object') {
-            w.watches[file] = fs.watch(file, opts, watcher);
-        }
-        else {
-            w.watches[file] = fs.watch(file, watcher);
-        }
+        fs.stat(file, function (err, stats) {
+            if (!err )
+                mtime = stats.mtime.getTime();
+            if (typeof opts === 'object') {
+                w.watches[file] = fs.watch(file, opts, watcher);
+            }
+            else {
+                w.watches[file] = fs.watch(file, watcher);
+            }
+        });
     };
+
+    var ifchanged = function (cb) {
+        fs.stat(file, function(err, stats) {
+            if (!err && stats.mtime.getTime() != mtime) {
+                mtime = stats.mtime.getTime();
+                cb();
+            }
+        });
+    };
+
     var pending = null;
     var bundle = function () {
         if (pending) return;
@@ -58,7 +73,7 @@ function reg (w, opts, body, file) {
                 w._cache = null;
             }
             else if (event === 'change') {
-                bundle();
+                ifchanged(bundle);
             }
             else if (event === 'rename') {
                 w.watches[file].close();


### PR DESCRIPTION
Currently, the watch reload the bundle even when only the access time of a file changes (at least on Windows). This change checks that the modification time changed.
