### PR TITLE
Compile coffee modules with bare: true

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ var exports = module.exports = function (entryFile, opts) {
     var w = wrap(opts_);
     w.register('.coffee', function (body, file) {
         try {
-            var res = coffee.compile(body, { filename : file });
+            var res = coffee.compile(body, { filename : file, bare: true });
         }
         catch (err) {
             w.emit('syntaxError', err);


### PR DESCRIPTION
This prevents the CoffeeScript compiler from wrapping the compiled
output in an (unnecessary) closure of it's own.
