### PR TITLE
Windows issues fixes

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -63,6 +63,20 @@ function Wrap (opts) {
     this.require('__browserify_process');
 }
 
+function resolveMod(from, to){
+    // not a real directory on the filesystem; just using the path
+    // module to get rid of the filename.
+    var targetDir = path.dirname(from);
+    // not a real filename; just using the path module to deal with
+    // relative paths.
+    var reqFilename = path.resolve(targetDir, to);
+    // get rid of drive letter on Windows; replace it with '/'
+    var reqFilenameWithoutDriveLetter = /^[a-zA-Z]:\\/.test(reqFilename) ?
+        '/' + reqFilename.substring(3) : reqFilename;
+
+    return reqFilenameWithoutDriveLetter;
+}
+
 util.inherits(Wrap, EventEmitter);
 
 Wrap.prototype.prepend = function (src) {
@@ -219,7 +233,7 @@ Wrap.prototype.addEntry = function (file_, opts) {
             fromFile : file,
         };
         if (opts.target && /^[.\/]/.test(req)) {
-            params.target = path.resolve(path.dirname(opts.target), req);
+            params.target = resolveMod(opts.target, req);
         }
         self.require(req, params);
     });
@@ -522,17 +536,7 @@ Wrap.prototype.require = function (mfile, opts) {
             fromFile : opts.file,
         };
         if (opts.target && /^[.\/]/.test(req)) {
-            // not a real directory on the filesystem; just using the path
-            // module to get rid of the filename.
-            var targetDir = path.dirname(opts.target);
-            // not a real filename; just using the path module to deal with
-            // relative paths.
-            var reqFilename = path.resolve(targetDir, req);
-            // get rid of drive letter on Windows; replace it with '/'
-            var reqFilenameWithoutDriveLetter = /^[A-Z]:\\/.test(reqFilename) ?
-                '/' + reqFilename.substring(3) : reqFilename;
-
-            params.target = idFromPath(reqFilenameWithoutDriveLetter);
+            params.target = idFromPath(resolveMod(opts.target, req));
         }
         self.require(req, params);
     });


### PR DESCRIPTION
I fixed some bug that happened on windows when I tried to browserify cucumber.js. Some module kept the c:/ in their name so I chase them down. It can now browserify cucumber.js on windows successfuly.

This my second Pull Request without the trash commit. The whitespace are now removed.
