### PR TITLE
Quiet about expressions

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -218,12 +218,6 @@ Wrap.prototype.addEntry = function (file_, opts) {
         return self;
     }
     
-    if (required.expressions.length) {
-        required.expressions.forEach(function (ex) {
-            console.error('    require(' + ex + ')');
-        });
-    }
-    
     var dirname = path.dirname(file);
     
     required.strings.forEach(function (req) {
@@ -520,12 +514,6 @@ Wrap.prototype.require = function (mfile, opts) {
         required.strings = required.strings.concat(
             pkg.browserify.require
         );
-    }
-    
-    if (required.expressions.length) {
-        required.expressions.forEach(function (ex) {
-            console.error('    require(' + ex + ')');
-        });
     }
     
     nub(required.strings).forEach(function (req) {


### PR DESCRIPTION
These aren't really errors. Or, at least, we know what we're doing.

We have private modules that, at require time, let us choose whether to import submodules. This keeps server code out of the client and vice versa.
