### PR TITLE
Add timers module.

### DIFF
--- a/builtins/timers.js
+++ b/builtins/timers.js
@@ -1,4 +1,35 @@
-exports.setTimeout = setTimeout;
-exports.clearTimeout = clearTimeout;
-exports.setInterval = setInterval;
-exports.clearInterval = clearInterval;
+try {
+    // Old IE browsers that do not curry arguments
+    if (!setTimeout.call) {
+        var slicer = Array.prototype.slice;
+        exports.setTimeout = function(fn) {
+            var args = slicer.call(arguments, 1);
+            return setTimeout(function() {
+                return fn.apply(this, args);
+            })
+        };
+
+        exports.setInterval = function(fn) {
+            var args = slicer.call(arguments, 1);
+            return setInterval(function() {
+                return fn.apply(this, args);
+            });
+        };
+    } else {
+        exports.setTimeout = setTimeout;
+        exports.setInterval = setInterval;
+    }
+    exports.clearTimeout = clearTimeout;
+    exports.clearInterval = clearInterval;
+
+    // Chrome seems to depend on `this` pseudo variable being a `window` and
+    // throws invalid invocation exception otherwise. If that's a case next
+    // line will throw and in `catch` clause window bound timer functions will
+    // be exported instead.
+    exports.setTimeout(function() {});
+} catch (_) {
+    exports.setTimeout = setTimeout.bind(window);
+    exports.clearTimeout = clearTimeout.bind(window);
+    exports.setInterval = setInterval.bind(window);
+    exports.clearInterval = clearInterval.bind(window);
+}

--- a/testling/test.sh
+++ b/testling/test.sh
@@ -18,11 +18,20 @@ function util () {
         'http://testling.com/?main=util.js&noinstrument=builtins/util.js'
 }
 
+function timers () {
+    tar -cf- timers.js ../builtins/timers.js |
+        curl -sSNT- -u "$user:$pass" \
+        'http://testling.com/?main=timers.js'
+}
+
 if test -z "$1"; then
     tick
     util
+    timers
 elif test "$1" == 'tick'; then
     tick
 elif test "$1" == 'util'; then
     util
+elif test "$1" == 'timers'; then
+    timers
 fi

--- a/testling/timers.js
+++ b/testling/timers.js
@@ -1,0 +1,50 @@
+var test = require('testling');
+var timers = require('./builtins/timers');
+
+test('setTimeout / clearTimeout', function (t) {
+    t.plan(3);
+    var arg1 = {}
+    var arg2 = {}
+    var async = false
+
+    timers.setTimeout(function(param1, param2) {
+      t.deepEqual(param1, arg1, '1st argument was curried');
+      t.deepEqual(param2, arg2, '2nd argument was curried');
+      t.ok(async, 'setTimeout is async');
+      timers.clearTimeout(id);
+    }, 10, arg1, arg2);
+
+    var id = timers.setTimeout(function() {
+      t.fail('timer had to be cleared');
+    }, 50);
+
+    timers.setTimeout(function() {
+      t.end();
+    }, 100);
+
+    async = true;
+});
+
+test('setInterval / clearInterval', function (t) {
+    t.plan(6);
+    var arg1 = {};
+    var arg2 = {};
+    var called = 0;
+    var async = false;
+
+    var id = timers.setInterval(function(param1, param2) {
+      called = called + 1;
+      t.deepEqual(param1, arg1, '1st argument was curried');
+      t.deepEqual(param2, arg2, '2nd argument was curried');
+      t.ok(async, 'setInterval invokes internal async');
+
+      if (called > 2) t.fail('internal had to be cleared')
+
+      if (called === 2) {
+        timers.clearInterval(id);
+        t.end();
+      }
+    }, 5, arg1, arg2);
+
+    async = true;
+});


### PR DESCRIPTION
In addon-sdk there are no global timer functions, so packages that
work there need to use [timers](http://nodejs.org/api/timers.html) module explicitly. Unfortunately they
break on borwserify since timers module does not exists here.
