### PR TITLE
Preserve path for individual file requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,8 @@ var exports = module.exports = function (entryFile, opts) {
                 var params = {};
                 if (needsNodeModulesPrepended(r)) {
                     params.target = '/node_modules/' + r + '/index.js';
+                } else if( r.match( /^\./ ) ) {
+                  params.target = path.resolve('/', r);
                 }
                 w.require(r, params);
             });


### PR DESCRIPTION
Was having an issue where if I did something like:

`browserify( { require : [ './lib/x.js', './lib/y.js' ] } );`

they would get defined as '/x.js' instead of './lib/x.js'. Wrote a quick patch that preserves the requested path.
