### PR TITLE
Expose filename when syntax error occurs

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ var exports = module.exports = function (entryFile, opts) {
             var res = coffee.compile(body, { filename : file });
         }
         catch (err) {
+            err.file = file;
             w.emit('syntaxError', err);
         }
         return res;

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -176,6 +176,7 @@ Wrap.prototype.readFile = function (file) {
         self.errors[file] = err;
         
         process.nextTick(function () {
+            err.file = file;
             self.emit('syntaxError', err);
         });
         return undefined;
@@ -213,6 +214,7 @@ Wrap.prototype.addEntry = function (file_, opts) {
                 + JSON.stringify(file)
                 + ': ' + err.message
             ;
+            err.file = file;
             self.emit('syntaxError', err);
         });
         return self;
@@ -512,6 +514,7 @@ Wrap.prototype.require = function (mfile, opts) {
     }
     catch (err) {
         process.nextTick(function () {
+            err.file = opts.file
             self.emit('syntaxError', err);
         });
         return self;


### PR DESCRIPTION
When a syntax error occurs the bundle object emits a `syntaxError` event with an object that includes some info such as the line number, but it does tell you which file the syntax error occurred in. The change is pretty minor and basically sets `err.file` to the filename before the event is emitted.

I am not sure if this the right approach. I saw that there is a `wrap.errors` object, but it doesn't seem that the `wrap` object is exposed through the bundle and even if it was it doesn't look like all errors are added to that `wrap.errors` object as my `bundle.ok` is `true` even after a syntax error is emitted.
