### PR TITLE
Use UTC format for last-modified header

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ var exports = module.exports = function (entryFile, opts) {
         if (req.url.split('?')[0] === (opts.mount || '/browserify.js')) {
             if (!w._cache) self.bundle();
             res.statusCode = 200;
-            res.setHeader('last-modified', self.modified.toString());
+            res.setHeader('last-modified', self.modified.toUTCString());
             res.setHeader('content-type', 'text/javascript');
             res.end(w._cache);
         }


### PR DESCRIPTION
I changed the last-modified header to use the ISO format instead of a local specific format. Now, some reverse proxies, like Varnish, can send a 304 Not Modified response if the client has the bundle in cache.
