### PR TITLE
return cached instance when requiring aliased module

### DIFF
--- a/test/alias.js
+++ b/test/alias.js
@@ -6,7 +6,7 @@ var browserify = require('../');
 var test = require('tap').test;
 
 test('alias', function (t) {
-    t.plan(5);
+    t.plan(8);
     var port = 10000 + Math.floor(Math.random() * (Math.pow(2,16) - 10000));
     var server = connect.createServer();
     
@@ -38,6 +38,9 @@ test('alias', function (t) {
                 vm.runInNewContext(src, context);
                 t.ok(context.require('moo'));
                 t.ok(context.require('seq'));
+                t.ok(context.require('seq') === context.require('seq'), 'returns the same instance for the same module');
+                t.ok(context.require('moo') === context.require('moo'), 'returns the same instance for the same module alias');
+                t.ok(context.require('seq') === context.require('moo'), 'returns the same instance for an aliased module and the original');
                 t.equal(
                     String(context.require('seq')),
                     String(context.require('moo'))

--- a/wrappers/prelude.js
+++ b/wrappers/prelude.js
@@ -12,6 +12,7 @@ var require = function (file, cwd) {
 require.paths = [];
 require.modules = {};
 require.cache = {};
+require.aliases = {};
 require.extensions = $extensions;
 
 require._core = {
@@ -38,7 +39,10 @@ require.resolve = (function () {
         }
         
         var n = loadNodeModulesSync(x, y);
-        if (n) return n;
+        if (n) {
+            if (require.aliases[n]) return require.aliases[n];
+            return n;
+        }
         
         throw new Error("Cannot find module '" + x + "'");
         
@@ -130,9 +134,11 @@ require.alias = function (from, to) {
         if (key.slice(0, basedir.length + 1) === basedir + '/') {
             var f = key.slice(basedir.length);
             require.modules[to + f] = require.modules[basedir + f];
+            require.aliases[to + f] = basedir + f;
         }
         else if (key === basedir) {
             require.modules[to] = require.modules[basedir];
+            require.aliases[to] = basedir;
         }
     }
 };


### PR DESCRIPTION
previously, if, for example, aliasing `jquery` to `jquary-browserify`, `require('jquery')` would always return a new instance of `jquery-browserify`, which is not how node's `require` works. This patch properly returns the same instance for aliased modules.
