### PR TITLE
add zlib-browserify to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "javascript"
     ],
     "dependencies" : {
+        "zlib-browserify": "0.0.1",
         "detective" : "~0.2.0",
         "buffer-browserify" : "~0.0.1",
         "console-browserify": "~0.1.0",


### PR DESCRIPTION
I couldn't figure out any other way to make browserify load `zlib-browserify` instead of `zlib` when it sees a `require("zlib")
