### PR TITLE
b.link(src, dest) API for using external libraries

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -33,6 +33,11 @@ b.on('error', function (err) {
     process.exit(1);
 });
 
+[].concat(argv.link).forEach(function (i) {
+  var s = i.split(':');
+  b.link(s[0], s[1]);
+});
+
 [].concat(argv.i).concat(argv.ignore).filter(Boolean)
     .forEach(function (i) { b.ignore(i) })
 ;


### PR DESCRIPTION
This method allows you to add an alias to an external library, such as CDN-hosted jQuery:

```
b.link('jquery', 'window.jQuery');
browserify entry.js --link jquery:window.jQuery > bundle.js
```

In a module:

```
var $ = require('jquery');
$(function() { ... });
```
