### PR TITLE
Pass opts to bundle

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,9 +99,9 @@ Browserify.prototype.bundle = function (opts, cb) {
     
     if (self._pending) {
         var tr = through();
-        
+
         self.on('_ready', function () {
-            self.bundle(cb).pipe(tr);
+            self.bundle(opts, cb).pipe(tr);
         });
         return tr;
     }


### PR DESCRIPTION
This fixes ignoring params on bundling.
