### PR TITLE
Permit to use a different directory for cache file

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -23,7 +23,7 @@ function idFromPath (path) {
 }
  
 function Wrap (opts) {
-    var home = process.env.HOME || process.env.USERPROFILE;
+    var home = process.env.BROWSERIFY_CACHE_DIR || process.env.HOME || process.env.USERPROFILE;
     if (opts.cache === undefined && home !== undefined) {
         opts.cache = true;
     }


### PR DESCRIPTION
While trying to run a nodejs software using browserify 1.X on Openshift, I found out that ~ is not writeable for security reason. So in order to put the cache somewhere else, I have added another environment variable so I can choose where to put the cache file.
