### PR TITLE
adding sourcemap support to browserify

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -8,14 +8,16 @@ var parseShell = require('shell-quote').parse;
 var duplexer = require('duplexer');
 
 var argv = require('optimist')
-    .boolean(['deps','pack','ig','dg', 'im'])
+    .boolean(['deps','pack','ig','dg', 'im', 'd'])
     .alias('insert-globals', 'ig')
     .alias('detect-globals', 'dg')
     .alias('ignore-missing', 'im')
+    .alias('debug', 'd')
     .alias('ig', 'fast')
     .default('ig', false)
     .default('im', false)
-    .default('dg', true)
+    .default('dg', true) 
+    .default('d', false) 
     .argv
 ;
 
@@ -44,7 +46,7 @@ b.on('error', function (err) {
 ;
 
 [].concat(argv.r).concat(argv.require).filter(Boolean)
-    .forEach(function (r) { b.require(r, { expose: r }) });
+    .forEach(function (r) { b.require(r, { expose: r }) })
 ;
 
 // resolve any external files and add them to the bundle as externals
@@ -98,7 +100,8 @@ if (argv.deps) {
 var bundle = b.bundle({
     detectGlobals: argv['detect-globals'] !== false && argv.dg !== false,
     insertGlobals: argv['insert-globals'] || argv.ig,
-    ignoreMissing: argv['ignore-missing'] || argv.im
+    ignoreMissing: argv['ignore-missing'] || argv.im,
+    debug:         argv['debug']          || argv.d
 });
 
 var outfile = argv.o || argv.outfile;

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -41,5 +41,9 @@ Advanced Options:
   --ignore-missing, --im            [default: false]
 
     Ignore `require()` statements that don't resolve to anything.
- 
+
+  --debug -s                        [default: false]
+    
+    Enable source maps that allow you to debug your files separately.
+
 Specify a parameter.

--- a/example/source_maps/build.js
+++ b/example/source_maps/build.js
@@ -1,0 +1,10 @@
+var browserify = require('../..'),
+    path = require('path'),
+    fs = require('fs'),
+    bundlePath = path.join(__dirname, 'js', 'build', 'bundle.js');
+
+browserify()
+    .require(require.resolve('./js/main.js'), { entry: true })
+    .bundle({ debug: true })
+    .on('error', function (err) { console.error(err); })
+    .pipe(fs.createWriteStream(bundlePath));

--- a/example/source_maps/build.sh
+++ b/example/source_maps/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+../../bin/cmd.js --debug -e ./js/main.js > js/build/bundle.js
+
+echo bundle was generated with source maps, you can now open index.html

--- a/example/source_maps/index.html
+++ b/example/source_maps/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=utf-8 />
+  <title></title>
+  <script type="text/javascript" src="./js/build/bundle.js"></script>
+</head>
+<body>
+  <p>Open your dev tools ;)</p>  
+</body>
+</html>

--- a/example/source_maps/js/build/.gitignore
+++ b/example/source_maps/js/build/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/example/source_maps/js/build/bundle.js
+++ b/example/source_maps/js/build/bundle.js
@@ -1,0 +1,28 @@
+;(function(e,t,n,r){function i(r){if(!n[r]){if(!t[r]){if(e)return e(r);throw new Error("Cannot find module '"+r+"'")}var s=n[r]={exports:{}};t[r][0](function(e){var n=t[r][1][e];return i(n?n:e)},s,s.exports)}return n[r].exports}for(var s=0;s<r.length;s++)i(r[s]);return i})(typeof require!=="undefined"&&require,{1:[function(require,module,exports){
+console.log('main line 1');
+var foo = require('./foo.js');
+
+foo();
+
+},{"./foo.js":2}],2:[function(require,module,exports){
+console.log('foo line 1');
+var bar = require('./wunder/bar');
+
+module.exports = function foo() {
+  console.log('hello from foo line 5');
+  bar();
+};
+
+},{"./wunder/bar":3}],3:[function(require,module,exports){
+console.log('bar line 1');
+'use strict';
+
+// this is a meaningless comment to add some lines
+
+module.exports = function bar() {
+  console.log('hello from bar line 7');
+};
+
+},{}]},{},[1])
+//@ sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyIvVXNlcnMvdGhsb3JlbnovZGV2L2pzL3Byb2plY3RzL2ZvcmtzL25vZGUtYnJvd3NlcmlmeS9leGFtcGxlL3NvdXJjZV9tYXBzL2pzL21haW4uanMiLCIvVXNlcnMvdGhsb3JlbnovZGV2L2pzL3Byb2plY3RzL2ZvcmtzL25vZGUtYnJvd3NlcmlmeS9leGFtcGxlL3NvdXJjZV9tYXBzL2pzL2Zvby5qcyIsIi9Vc2Vycy90aGxvcmVuei9kZXYvanMvcHJvamVjdHMvZm9ya3Mvbm9kZS1icm93c2VyaWZ5L2V4YW1wbGUvc291cmNlX21hcHMvanMvd3VuZGVyL2Jhci5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTs7QUNKQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBOztBQ1BBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQSIsInNvdXJjZVJvb3QiOiJmaWxlOi8vbG9jYWxob3N0Iiwic291cmNlQ29udGVudCI6WyJjb25zb2xlLmxvZygnbWFpbiBsaW5lIDEnKTtcbnZhciBmb28gPSByZXF1aXJlKCcuL2Zvby5qcycpO1xuXG5mb28oKTtcbiIsImNvbnNvbGUubG9nKCdmb28gbGluZSAxJyk7XG52YXIgYmFyID0gcmVxdWlyZSgnLi93dW5kZXIvYmFyJyk7XG5cbm1vZHVsZS5leHBvcnRzID0gZnVuY3Rpb24gZm9vKCkge1xuICBjb25zb2xlLmxvZygnaGVsbG8gZnJvbSBmb28gbGluZSA1Jyk7XG4gIGJhcigpO1xufTtcbiIsImNvbnNvbGUubG9nKCdiYXIgbGluZSAxJyk7XG4ndXNlIHN0cmljdCc7XG5cbi8vIHRoaXMgaXMgYSBtZWFuaW5nbGVzcyBjb21tZW50IHRvIGFkZCBzb21lIGxpbmVzXG5cbm1vZHVsZS5leHBvcnRzID0gZnVuY3Rpb24gYmFyKCkge1xuICBjb25zb2xlLmxvZygnaGVsbG8gZnJvbSBiYXIgbGluZSA3Jyk7XG59O1xuIl19
+;

--- a/example/source_maps/js/foo.js
+++ b/example/source_maps/js/foo.js
@@ -1,0 +1,7 @@
+console.log('foo line 1');
+var bar = require('./wunder/bar');
+
+module.exports = function foo() {
+  console.log('hello from foo line 5');
+  bar();
+};

--- a/example/source_maps/js/main.js
+++ b/example/source_maps/js/main.js
@@ -1,0 +1,4 @@
+console.log('main line 1');
+var foo = require('./foo.js');
+
+foo();

--- a/example/source_maps/js/wunder/bar.js
+++ b/example/source_maps/js/wunder/bar.js
@@ -1,0 +1,8 @@
+console.log('bar line 1');
+'use strict';
+
+// this is a meaningless comment to add some lines
+
+module.exports = function bar() {
+  console.log('hello from bar line 7');
+};

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ Browserify.prototype.bundle = function (opts, cb) {
         })
         : through()
     ;
-    var p = self.pack();
+    var p = self.pack(opts.debug);
     if (cb) {
         var data = '';
         p.on('data', function (buf) { data += buf });
@@ -194,14 +194,20 @@ Browserify.prototype.deps = function (opts) {
     }
 };
 
-Browserify.prototype.pack = function () {
+Browserify.prototype.pack = function (debug) {
     var self = this;
     var packer = browserPack({ raw: true });
     var ids = {};
     var idIndex = 1;
+    var root = process.cwd();
     
     var input = through(function (row) {
         var ix;
+
+        if (debug) { 
+            row.sourceRoot = 'file://localhost'; 
+            row.sourceFile = row.id;
+        }
 
         if (row.exposed) {
             ix = row.exposed;
@@ -233,6 +239,7 @@ Browserify.prototype.pack = function () {
             acc[key] = ids[file];
             return acc;
         }, {});
+        
         this.queue(row);
     });
     
@@ -259,7 +266,7 @@ Browserify.prototype.pack = function () {
     
     function end () {
         if (first) writePrelude();
-        this.queue(';');
+        this.queue('\n;');
         this.queue(null);
     }
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ],
     "dependencies": {
         "module-deps": "~0.5.0",
-        "browser-pack": "~0.3.0",
+        "browser-pack": "git://github.com/thlorenz/browser-pack.git",
         "shell-quote": "~0.0.1",
         "through": "~2.2.0",
         "duplexer": "~0.0.2",

--- a/readme.markdown
+++ b/readme.markdown
@@ -162,6 +162,10 @@ Advanced Options:
   --ignore-missing, --im            [default: false]
 
     Ignore `require()` statements that don't resolve to anything.
+
+  --debug -s                        [default: false]
+    
+    Enable source maps that allow you to debug your files separately.
  
 Specify a parameter.
 ```

--- a/test/bundle_sourcemap.js
+++ b/test/bundle_sourcemap.js
@@ -1,0 +1,30 @@
+var browserify = require('../');
+var test = require('tap').test;
+
+test('bundle in debug mode', function (t) {
+    var b = browserify();
+    b.require('seq');
+    b.bundle({ debug: true }, function (err, src) {
+        t.plan(3);
+        
+        var secondtolastLine = src.split('\n').slice(-2);
+
+        t.ok(typeof src === 'string');
+        t.ok(src.length > 0);
+        t.ok(/^\/\/@ sourceMappingURL=/.test(secondtolastLine), 'includes sourcemap');
+    });
+});
+
+test('bundle in non debug mode', function (t) {
+    var b = browserify();
+    b.require('seq');
+    b.bundle(function (err, src) {
+        t.plan(3);
+        
+        var secondtolastLine = src.split('\n').slice(-2);
+
+        t.ok(typeof src === 'string');
+        t.ok(src.length > 0);
+        t.notOk(/^\/\/@ sourceMappingURL=/.test(secondtolastLine), 'includes no sourcemap');
+    });
+});


### PR DESCRIPTION
This still depends on my fork of browser-pack.
So we first would need to merge [this](https://github.com/substack/browser-pack/pull/4), publish as new version and the nchange the dependency.

At this point only a `--debug` flag is supported which inlines sources by default and puts sourceRootURL at the root of the file system.
In the future we should support more flags, to opt out of inlining sources (keep bundle smaller) and to point sourceRootURL wherever we like.

I'll add these in a later PR, at this point I wanted to get the minimum functionality in.
