### PR TITLE
Added the ability to require dependencies relative to the cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,6 +281,7 @@ var emptyModulePath = require.resolve('./_empty');
 Browserify.prototype._resolve = function (id, parent, cb) {
     var self = this;
     if (self._mapped[id]) return cb(null, self._mapped[id]);
+    parent.paths.push(process.cwd());
     
     return browserResolve(id, parent, function(err, file) {
         if (err) return cb(err);


### PR DESCRIPTION
We have a fairly complicated project tree and we'd like to be able to require things with browserify relative to the cwd. So instead of writing `require('../../../../../app/out/models/mockup.js')` which is prone to change, we can write `require('app/out/models/mockup.js')` instead which is far less prone to change.

Another way to do this (which could be preferable) is:

``` javascript
// in our code
module.paths.push(process.cwd());
// in browserify
parent.paths = parent.paths.concat(module.paths);
```

or via an option.

It seems something like this is intended with https://github.com/balupton/node-browserify/blob/7ae499aa71f23d146af9d2dbd4e2f41403c9e218/index.js#L50 but I may be wrong about that.
