### PR TITLE
Cyclical requires will return the correct exports object reference on a cache hit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,16 +224,12 @@ Browserify.prototype.pack = function (debug) {
         row.deps = Object.keys(row.deps).reduce(function (acc, key) {
             var file = row.deps[key];
 
-            // reference external files directly by hash
-            if (self._external[file]) {
+            // reference external and exposed files directly by hash
+            if (self._external[file] || self._expose[file]) {
                 acc[key] = hash(file);
                 return acc;
             }
 
-            if (self._expose[file]) {
-                acc[key] = self._expose[file];
-                return acc;
-            }
             if (ids[file] === undefined) ids[file] = idIndex++;
             acc[key] = ids[file];
             return acc;


### PR DESCRIPTION
When doing a cyclical requires the current implementation had exposed module names alias to hashed file names by creating a function that performed a requires to the hashed module name. When the hashed module code ran and made a cyclical requires, the local module resolution resolved to the name of the aliased module.

That aliased module had a separately created exports object reference, and because we were still in the middle of a require, that exports object reference had not been updated yet, so we were getting a cache hit to the wrong exports object reference.

The fix I am proposing is to have the local module resolution resolve directly to the hashed file name module which will return the correct exports object reference on the cache hit. The old method of calling the aliased module introduces new code into the middle of the module execution and causes this side effect.

This fix fixes issue #333 which I submitted.
