### PR TITLE
Fix a bug with b.require if {expose:true}

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ Browserify.prototype.pack = function (debug) {
             var file = row.deps[key];
 
             // reference external and exposed files directly by hash
-            if (self._external[file] || self._expose[file]) {
+            if (self._external[file] || self.exports[file]) {
                 acc[key] = hash(file);
                 return acc;
             }


### PR DESCRIPTION
If I expose a file without giving a name ({expose:true}), hoping for it to use the file hash, a bug may happen inside the bundle : the file is exposed with hash, but internally referenced with id number.

At https://github.com/substack/node-browserify/blob/e7fc5cb470a3bef22328f69e5c5461549dbede36/index.js#L217
If the exposed file was already seen in a dependency, an id number was generated and the hash is not used here.
