### PR TITLE
Change script filename in example

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -36,7 +36,7 @@ Now just use the `browserify` command to build a bundle starting at `main.js`:
 $ browserify main.js > bundle.js
 ```
 
-All of the modules that `entry.js` needs are included in the `bundle.js` from a
+All of the modules that `main.js` needs are included in the `bundle.js` from a
 recursive walk of the `require()` graph using
 [required](https://github.com/shtylman/node-required).
 


### PR DESCRIPTION
I assume this should be `main` rather than `entry`. Wasn't exactly clear to me where `entry.js` suddenly came from.
