### PR TITLE
Add failing test: reverse multi bundle

### DIFF
--- a/test/reverse_multi_bundle.js
+++ b/test/reverse_multi_bundle.js
@@ -1,0 +1,43 @@
+/**
+ * To be able to lazy load bundles with script loaders the loaded bundles
+ * must have access to modules exposed by previous bundles.
+ *
+ * In effect this is the same as adding the bundles in reverse order
+ **/
+
+var browserify = require('../');
+var vm = require('vm');
+var test = require('tap').test;
+
+test('reverse multi bundle', function (t) {
+    t.plan(4);
+
+    // Main app bundle has the main app code and the shared libarary code
+    var app = browserify([__dirname + '/reverse_multi_bundle/app.js'])
+        .external(__dirname + '/reverse_multi_bundle/lazy.js')
+        .require(__dirname + '/reverse_multi_bundle/shared.js');
+
+    // Lazily loaded bundle has only its own code even it uses code from the
+    // shared library.
+    var lazy = browserify()
+        .require(__dirname + '/reverse_multi_bundle/lazy.js')
+        .external(__dirname + '/reverse_multi_bundle/shared.js');
+
+
+    app.bundle(function (err, appSrc) {
+        if (err) throw err;
+        lazy.bundle(function(err, lazySrc) {
+            if (err) throw err;
+
+            var src = appSrc  + lazySrc;
+            var c = {
+                setTimeout: setTimeout,
+                t: t
+            };
+            vm.runInNewContext(src, c);
+        });
+
+    });
+
+
+});

--- a/test/reverse_multi_bundle/app.js
+++ b/test/reverse_multi_bundle/app.js
@@ -1,0 +1,22 @@
+
+t.equal(
+    require("./shared")(), 1,
+    "the main app bundle can already use the shared library"
+);
+
+t.throws(function() {
+    require("./lazy");
+}, "lazy bundle is not executed yet so the lazy module cannot be required yet");
+
+// Use setTimeout as script loader simulator as in real use case this would be
+// a call to one. Now we just let the rest of the source code string we build
+// to execute.
+setTimeout(function() {
+    // After lazy bundle is executed we can require the lazy.js module
+    require("./lazy");
+    t.equal(
+        require("./shared")(),3,
+        "lazy module was able to use shared code"
+    );
+}, 1);
+

--- a/test/reverse_multi_bundle/lazy.js
+++ b/test/reverse_multi_bundle/lazy.js
@@ -1,0 +1,4 @@
+t.equal(
+  require("./shared")(),2,
+  "lazy.js can use the shared library"
+);

--- a/test/reverse_multi_bundle/shared.js
+++ b/test/reverse_multi_bundle/shared.js
@@ -1,0 +1,4 @@
+var i = 0;
+module.exports = function() {
+    return ++i;
+};


### PR DESCRIPTION
On the way to enable lazy asynchronous bundle loading :)

Fixed in browser-pack pull request https://github.com/substack/browser-pack/pull/10
