### PR TITLE
fixing a path issue in ignores CLI

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -51,7 +51,7 @@ b.on('error', function (err) {
 });
 
 [].concat(argv.i).concat(argv.ignore).filter(Boolean)
-    .forEach(function (i) { b.ignore(i) })
+    .forEach(function (i) { b.ignore(path.resolve(process.cwd(), i)) })
 ;
 
 [].concat(argv.r).concat(argv.require).filter(Boolean)


### PR DESCRIPTION
the `--ignores` CLI arg doesn't resolve path in the same way as other CLI args. 
