### PR TITLE
Globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "concat-stream": "~0.1.1",
         "insert-module-globals": "~0.2.0",
         "syntax-error": "~0.0.0",
-        "browser-resolve": "git://github.com/amiuhle/node-browser-resolve.git#chrome-app-sockets",
+        "browser-resolve": "~0.1.1",
         "inherits": "~1.0.0",
         "optimist": "~0.3.5",
         "JSONStream": "~0.4.3",


### PR DESCRIPTION
Option to add provide custom global `process` and `Buffer` implementations, currently only via `grunt-browserify`:

``` javascript
browserify: {
  bundle: {
    src: [],
    require: ['mongodb', 'tcp_wrap-chromeify'],
    dest: 'app/scripts/vendor/bundle.js',
    ignore: 'node_modules/browser-resolve/node_modules/buffer-browserify/index.js',
    options: {
      globals: {
        process: 'browser-resolve/builtin/process',
        Buffer: 'buffer-browserify'
      }
    }
  }
}
```
