### PR TITLE
Support filenames in browser-pack

### DIFF
--- a/bin/advanced.txt
+++ b/bin/advanced.txt
@@ -15,6 +15,13 @@ Advanced Options:
 
     benefit: npm modules more likely to work
     cost: slower builds
+ 
+  --include-filenames, --if         [default: true]
+
+    Set module.filename on all client-side module objects, based on source filename.  (strips common paths)
+
+    benefit: some npm modules more likely to work
+    cost: extra bytes
 
   --ignore-missing, --im            [default: false]
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -9,10 +9,11 @@ var duplexer = require('duplexer');
 var through = require('through');
 
 var argv = require('optimist')
-    .boolean(['deps','pack','ig','dg', 'im', 'd','list'])
+    .boolean(['deps','pack','ig','dg','if', 'im', 'd','list'])
     .string(['s'])
     .alias('insert-globals', 'ig')
     .alias('detect-globals', 'dg')
+    .alias('include-filenames', 'if')
     .alias('ignore-missing', 'im')
     .alias('debug', 'd')
     .alias('standalone', 's')
@@ -20,6 +21,7 @@ var argv = require('optimist')
     .default('ig', false)
     .default('im', false)
     .default('dg', true) 
+    .default('if', true) 
     .default('d', false) 
     .argv
 ;
@@ -126,6 +128,7 @@ if (argv.standalone === true) {
 var bundle = b.bundle({
     detectGlobals: argv['detect-globals'] !== false && argv.dg !== false,
     insertGlobals: argv['insert-globals'] || argv.ig,
+    filenames: argv['include-filenames'] || argv.if,
     ignoreMissing: argv['ignore-missing'] || argv.im,
     debug: argv['debug'] || argv.d,
     standalone: argv['standalone'] || argv.s

--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ Browserify.prototype.bundle = function (opts, cb) {
     if (opts.detectGlobals === undefined) opts.detectGlobals = true;
     if (opts.ignoreMissing === undefined) opts.ignoreMissing = false;
     if (opts.standalone === undefined) opts.standalone = false;
+    if (opts.filenames === undefined) opts.filenames = true;
     
     opts.resolve = self._resolve.bind(self);
     opts.transform = self._transforms;
@@ -146,7 +147,7 @@ Browserify.prototype.bundle = function (opts, cb) {
         })
         : through()
     ;
-    var p = self.pack(opts.debug, opts.standalone);
+    var p = self.pack(opts.debug, opts.standalone, opts.filenames);
     if (cb) {
         p.on('error', cb);
         p.pipe(concatStream(cb));
@@ -213,9 +214,9 @@ Browserify.prototype.deps = function (opts) {
     }
 };
 
-Browserify.prototype.pack = function (debug, standalone) {
+Browserify.prototype.pack = function (debug, standalone, filenames) {
     var self = this;
-    var packer = browserPack({ raw: true });
+    var packer = browserPack({ raw: true, filenames: filenames });
     var ids = {};
     var idIndex = 1;
 
@@ -224,6 +225,8 @@ Browserify.prototype.pack = function (debug, standalone) {
     var input = through(function (row) {
         var ix;
 
+        if (filenames)
+            row.filename = row.id;
         if (debug) { 
             row.sourceRoot = 'file://localhost'; 
             row.sourceFile = row.id;


### PR DESCRIPTION
Defaults to true

Requires SLaks/browser-pack@de48689

Without this PR, browser-pack will only be able to see filenames if source maps are enabled.
