### PR TITLE
Check raw require() ids against ignore list

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,6 +303,7 @@ var packageFilter = function (info) {
 
 var emptyModulePath = require.resolve('./_empty');
 Browserify.prototype._resolve = function (id, parent, cb) {
+    if (this._ignore[id]) return cb(null, emptyModulePath);
     var self = this;
     var result = function (file, x) {
         self.emit('file', file, id, parent);

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -14,3 +14,20 @@ test('ignore', function (t) {
         vm.runInNewContext(src, { t: t });
     });
 });
+
+test('ignore by package or id', function (t) {
+    t.plan(4);
+  
+    var b = browserify();
+    b.add(__dirname + '/ignore/by-id.js');
+    b.ignore('events');
+    b.ignore('beep');
+    b.ignore('bad id');
+    b.ignore('./skip.js');
+  
+    b.bundle(function (err, src) {
+        if (err) t.fail(err);
+        console.error(err,src);
+        vm.runInNewContext(src, { t: t });
+    });
+});

--- a/test/ignore/by-id.js
+++ b/test/ignore/by-id.js
@@ -1,0 +1,4 @@
+t.deepEqual(require('events'), {});
+t.deepEqual(require('bad id'), {});
+t.deepEqual(require('beep'), {});
+t.deepEqual(require('./skip.js'), {});


### PR DESCRIPTION
ignore now works with relative paths and module names.

Fixes #398
