### PR TITLE
Add deAMDify to list of source transforms.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -389,6 +389,9 @@ Here is a list of known source transforms:
 * [caching-coffeeify](https://github.com/thlorenz/caching-coffeeify) - coffeeify
 version that caches previously compiled files to optimize the compilation step
 
+* [deAMDify](https://github.com/jaredhanson/deamdify) - translate AMD modules
+to Node-style modules automatically
+
 * [hbsfy](https://github.com/epeli/node-hbsfy) - precompile handlebars
 templates to javascript functions automatically
 


### PR DESCRIPTION
With this transform you can freely intermix Node and AMD modules for inclusion into the compiled bundle.
