### PR TITLE
Support package metadata in resolution process.

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,16 +336,16 @@ var emptyModulePath = require.resolve('./_empty');
 Browserify.prototype._resolve = function (id, parent, cb) {
     if (this._ignore[id]) return cb(null, emptyModulePath);
     var self = this;
-    var result = function (file, x) {
+    var result = function (file, pkg, x) {
         if (self._pending === 0) {
             self.emit('file', file, id, parent);
         }
-        cb(null, file, x);
+        cb(null, file, pkg, x);
     };
     if (self._mapped[id]) return result(self._mapped[id]);
     
     parent.modules = browserBuiltins;
-    return browserResolve(id, parent, function(err, file) {
+    return browserResolve(id, parent, function(err, file, pkg) {
         if (err) return cb(err);
         if (!file) return cb(new Error('module '
             + JSON.stringify(id) + ' not found from '
@@ -353,9 +353,9 @@ Browserify.prototype._resolve = function (id, parent, cb) {
         ));
         
         if (self._ignore[file]) return cb(null, emptyModulePath);
-        if (self._external[file]) return result(file, true);
+        if (self._external[file]) return result(file, undefined, true);
         
-        result(file);
+        result(file, pkg);
     });
 };
 


### PR DESCRIPTION
This patch builds on the support of the following patches to browserify's dependencies:

https://github.com/substack/node-resolve/pull/21
https://github.com/shtylman/node-browser-resolve/pull/23
https://github.com/substack/module-deps/issues/13

With all this in place, transforms are correctly applied to any package dependencies.

Whew! I think that's it. I'd love to get all this merged and published to npm.  Please let me know if there's any questions or changes that need to be made.

Cheers!
