### PR TITLE
Fix typo in readme.markdown

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -246,7 +246,7 @@ var browserify = require('browserify')
 
 ## var b = browserify(files=[] or opts={})
 
-Create a browserify instance `b` from the entry main `files` or `opts.files`.
+Create a browserify instance `b` from the entry main `files` or `opts.entries`.
 `files` can be an array of files or a single file.
 
 You can also specify an `opts.noParse` array which will skip all require() and


### PR DESCRIPTION
If passed as a hash it should be `opts.entries` not `opts.files`, not sure if you want to change the rest of the words around it from files to entries too?
