### PR TITLE
Update to browser-resolve 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "concat-stream": "~0.1.1",
         "insert-module-globals": "~0.2.0",
         "syntax-error": "~0.0.0",
-        "browser-resolve": "git://github.com/substack/node-browser-resolve.git#dir-replace",
+        "browser-resolve": "~1.1.0",
         "browser-builtins": "~1.0.1",
         "inherits": "~1.0.0",
         "optimist": "~0.5.1",

--- a/test/field.js
+++ b/test/field.js
@@ -32,7 +32,7 @@ test('fieldObject', function (t) {
         vm.runInNewContext(src, c);
         t.equal(
             c.require('./object.js'),
-            'browser'
+            '!browser'
         );
     });
 });


### PR DESCRIPTION
Update to browser-resolve 1.1.0 now that the necessary patches for #420 have been merged and published.

The  test change reverts back to the original test that was changed here:
https://github.com/substack/node-browserify/commit/fac795d82cf5bcb1ae0d282480e11437fe080cf9#L2L31

The difference was cause by `packageFilter` within browser-resolve 1.0.1 being too generous in its legacy check (https://github.com/shtylman/node-browser-resolve/blob/v1.0.1/index.js#L145)

Now (https://github.com/shtylman/node-browser-resolve/blob/master/index.js#L154) it uses the same check as browserify itself (https://github.com/substack/node-browserify/blob/master/index.js#L332)
