### PR TITLE
Changed ignore to external in multiple bundles build script

### DIFF
--- a/example/multiple_bundles/build.sh
+++ b/example/multiple_bundles/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 browserify -r ./robot.js > static/common.js
-browserify -i ./robot.js beep.js > static/beep.js
-browserify -i ./robot.js boop.js > static/boop.js
+browserify -x ./robot.js beep.js > static/beep.js
+browserify -x ./robot.js boop.js > static/boop.js


### PR DESCRIPTION
The multiple bundles example was not working. Fixed as proposed in #291
