### PR TITLE
Use transforms with --deps and --list flags.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -37,13 +37,15 @@ if (b.argv.pack) {
 
 if (b.argv.deps) {
     var stringify = JSONStream.stringify();
-    var d = b.deps({ packageFilter: packageFilter });
+    var t = [].concat(b.argv.t).concat(b.argv.transform);
+    var d = b.deps({ packageFilter: packageFilter, transform: t });
     d.pipe(stringify).pipe(process.stdout);
     return;
 }
 
 if (b.argv.list) {
-    var d = b.deps({ packageFilter: packageFilter });
+    var t = [].concat(b.argv.t).concat(b.argv.transform);
+    var d = b.deps({ packageFilter: packageFilter, transform: t });
     d.pipe(through(function (dep) {
         this.queue(dep.id + '\n');
     })).pipe(process.stdout);


### PR DESCRIPTION
Unless the source transforms are included when using `--list` or `--deps`, some builds will fail with a syntax error - e.g. when using brfs. Simple fix :)
