### PR TITLE
Allow arbitrary external ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,11 +85,13 @@ Browserify.prototype.require = function (id, opts) {
         packageFilter: packageFilter
     };
     browserResolve(id, params, function (err, file) {
-        if (err) return self.emit('error', err);
-        if (!file) return self.emit('error', new Error(
-            'module ' + JSON.stringify(id) + ' not found in require()'
-        ));
-        
+        if ((err || !file) && !opts.external) {
+            if (err) return self.emit('error', err);
+            if (!file) return self.emit('error', new Error(
+                'module ' + JSON.stringify(id) + ' not found in require()'
+            ));
+        }
+
         if (opts.expose) {
             self.exports[file] = hash(file);
             
@@ -100,7 +102,8 @@ Browserify.prototype.require = function (id, opts) {
         }
 
         if (opts.external) {
-            self._external[file] = true;
+            if (file) self._external[file] = true;
+            else self._external[id] = true;
         }
         else {
             self.files.push(file);

--- a/test/reverse_multi_bundle.js
+++ b/test/reverse_multi_bundle.js
@@ -10,34 +10,37 @@ var vm = require('vm');
 var test = require('tap').test;
 
 test('reverse multi bundle', function (t) {
-    t.plan(4);
+    t.plan(5);
 
     // Main app bundle has the main app code and the shared libarary code
     var app = browserify([__dirname + '/reverse_multi_bundle/app.js'])
         .external(__dirname + '/reverse_multi_bundle/lazy.js')
-        .require(__dirname + '/reverse_multi_bundle/shared.js');
+        .require(__dirname + '/reverse_multi_bundle/shared.js')
+        .require(__dirname + '/reverse_multi_bundle/arbitrary.js', {expose: 'not/real'});
 
     // Lazily loaded bundle has only its own code even it uses code from the
     // shared library.
     var lazy = browserify()
         .require(__dirname + '/reverse_multi_bundle/lazy.js')
-        .external(__dirname + '/reverse_multi_bundle/shared.js');
+        .external(__dirname + '/reverse_multi_bundle/shared.js')
+        .external('not/real');
 
 
     app.bundle(function (err, appSrc) {
         if (err) throw err;
-        lazy.bundle(function(err, lazySrc) {
-            if (err) throw err;
+        lazy.bundle({
+            filter: function (id) {
+                return id !== 'not/real';
+            }
+        },  function(err, lazySrc) {
+                if (err) throw err;
 
-            var src = appSrc  + lazySrc;
-            var c = {
-                setTimeout: setTimeout,
-                t: t
-            };
-            vm.runInNewContext(src, c);
+                var src = appSrc  + lazySrc;
+                var c = {
+                    setTimeout: setTimeout,
+                    t: t
+                };
+                vm.runInNewContext(src, c);
         });
-
     });
-
-
 });

--- a/test/reverse_multi_bundle/arbitrary.js
+++ b/test/reverse_multi_bundle/arbitrary.js
@@ -1,0 +1,4 @@
+var i = 0;
+module.exports = function() {
+    return ++i;
+};

--- a/test/reverse_multi_bundle/lazy.js
+++ b/test/reverse_multi_bundle/lazy.js
@@ -2,3 +2,8 @@ t.equal(
   require("./shared")(),2,
   "lazy.js can use the shared library"
 );
+t.equal(
+  require("not/real")(),1,
+  "lazy.js can use library code with arbitrary names"
+);
+


### PR DESCRIPTION
Right now, ids used to reference modules in external bundles are
required to correspond to actual files, but it'd be helpful if these ids
could be arbitrary. This issue has been brought up in #387 and #472.

A small change to how external modules are loaded, combined with using
the mdeps filter option, allows for arbitrary external ids. This commit
includes test coverage.
