### PR TITLE
Fix error when inserting globals and expose-ing

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,6 +267,7 @@ Browserify.prototype.deps = function (opts) {
         
         if (self._expose[row.id]) {
             this.queue({
+                id: row.id,
                 exposed: self._expose[row.id],
                 deps: {},
                 source: 'module.exports=require(\'' + hash(row.id) + '\');'

--- a/test/global.js
+++ b/test/global.js
@@ -17,6 +17,21 @@ test('global', function (t) {
     });
 });
 
+test('__filename and __dirname with insertGlobals: true', function (t) {
+    t.plan(2);
+
+    var b = browserify();
+    b.require(__dirname + '/global/filename.js', {expose: 'x'});
+    b.bundle({insertGlobals: true}, function (err, src) {
+        var c = {};
+        c.self = c;
+        vm.runInNewContext(src, c);
+        var x = c.require('x');
+        t.equal(x.filename, '/filename.js');
+        t.equal(x.dirname, '/');
+    });
+});
+
 test('__filename and __dirname', function (t) {
     t.plan(2);
     


### PR DESCRIPTION
I was experiencing an issue when trying to use [browserify-shim](https://github.com/thlorenz/browserify-shim) and [requireify](https://github.com/johnkpaul/requireify). Requireify requires --insert-globals to be set in order to get __filename access at runtime. When I tried to mesh the two together, I was getting this error:

```
path.js:313
        throw new TypeError('Arguments to path.resolve must be strings');
              ^
TypeError: Arguments to path.resolve must be strings
    at Object.exports.resolve (path.js:313:15)
    at Object.exports.relative (path.js:371:18)
    at Stream._vars.__filename (/Users/jpaul/workspace/browserify-shim/node_modules/browserify/node_modules/insert-module-globals/index.js:32:31)
```

I tracked this down to browserify not passing a row object with an `id` property to insert-globals when using `b.require(path, {expose:name});`. I've added that property to the output of .deps().
