### PR TITLE
downgrading browser-builtins

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "insert-module-globals": "~1.3.0",
         "syntax-error": "~0.0.0",
         "browser-resolve": "~1.1.0",
-        "browser-builtins": "~2.0.2",
+        "browser-builtins": "~1.0.7",
         "inherits": "~1.0.0",
         "optimist": "~0.5.1",
         "JSONStream": "~0.6.4",


### PR DESCRIPTION
The current version of `browser-builtins` [breaks multilevel](https://github.com/substack/node-browserify/issues/492).

Downgrading them to an earlier version fixes this issue.
