### PR TITLE
update umd version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "inherits": "~1.0.0",
         "optimist": "~0.5.1",
         "JSONStream": "~0.6.4",
-        "umd": "~1.1.0",
+        "umd": "~1.3.1",
         "parents": "~0.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
the version of `umd` that is being required throws an error inside a web worker where 'global' isn't always defined. 
