### PR TITLE
Replace backslashes with slashes in sourcemaps paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,7 +312,7 @@ Browserify.prototype.pack = function (debug, standalone) {
         
         if (debug) { 
             row.sourceRoot = 'file://localhost'; 
-            row.sourceFile = row.id;
+            row.sourceFile = row.id.replace(/\\/g, '/');
         }
         
         var dup = hashes[row.hash];


### PR DESCRIPTION
This fixes the folder display in Chrome/Firefox with Windows style paths
