### PR TITLE
Added phantomjsify to README

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -455,6 +455,9 @@ hypothetical es6 with lua's return
   javascript used in [react](http://facebook.github.io/react/) UI library) files
   to javascript
 
+* [phantomjsify](https://github.com/twolfson/phantomjsify) - shim out node.js
+  core for [PhantomJS](http://phantomjs.org/)
+
 # third-party tools
 
 If you want to efficiently re-compile the bundle automatically when you edit


### PR DESCRIPTION
I have created a `browserify` transform that shims node.js core for PhantomJS. This PR adds `phantomjsify` to the list of transforms.

https://github.com/twolfson/phantomjsify
