### PR TITLE
Re-ordered bundle() callback fixing to before pending check

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,14 @@ Browserify.prototype.bundle = function (opts, cb) {
         if (parentFilter) pkg = parentFilter(pkg);
         return packageFilter(pkg);
     };
-    
+
+    if (cb) cb = (function (f) {
+        return function () {
+            if (f) f.apply(this, arguments);
+            f = null;
+        };
+    })(cb);
+
     if (self._pending) {
         var tr = through();
         self.on('_ready', function () {
@@ -207,13 +214,7 @@ Browserify.prototype.bundle = function (opts, cb) {
         });
         return tr;
     }
-    if (cb) cb = (function (f) {
-        return function () {
-            if (f) f.apply(this, arguments);
-            f = null;
-        };
-    })(cb);
-    
+
     if (opts.standalone && self._entries.length !== 1) {
         process.nextTick(function () {
             p.emit('error', 'standalone only works with a single entry point');


### PR DESCRIPTION
cb358b265441b088a232e3bf581601af5e74582e added a fix for potential double callbacks, but it didn't quite catch the case where a bundle was pending because that makes a recursive call with the un-fixed `cb`, and so some cases were still calling back more than once.

Moving the callback fix to before the point at which the code branched for pending bundles fixes this.
