### PR TITLE
folderify transform

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -457,8 +457,8 @@ hypothetical es6 with lua's return
 
 * [browserify-shim](https://github.com/thlorenz/browserify-shim) - make commonJS-incompatible libraries/files browserifyable
 
-* [folderify](https://github.com/parroit/folderify) - include whole static content of a directory imported using 
-[import-folder](https://github.com/parroit/import-folder) via [brfs](https://github.com/substack/brfs)
+* [folderify](https://github.com/parroit/folderify) - inline content of a directory imported using 
+[include-folder](https://github.com/parroit/include-folder). Files content is inlined using [brfs](https://github.com/substack/brfs)
 
 
 


### PR DESCRIPTION
Added [folderify](https://github.com/parroit/folderify) to tranforms.

Folderify inline a whole directory content in browserify results.
1. It uses falafel to intercepts calls to [include-folder](https://github.com/parroit/include-folder) 
2. use include-folder to generate source code of a function with a fs.readFileSync call for each file in directory
3. feed brfs stream with generated source code 
4. replace include-folder call with brfs output
