### PR TITLE
Added cacheify to the list of known transforms in the README

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -428,6 +428,8 @@ files written using [bliss](https://github.com/cstivers78/bliss)
 * [brfs](https://github.com/substack/brfs) - inline
 `fs.readFileSync()` calls with file contents
 
+* [cacheify](https://github.com/bockit/cacheify) - wraps around other transforms, caching their results to speed up bundling.
+
 * [caching-coffeeify](https://github.com/thlorenz/caching-coffeeify) - coffeeify
 version that caches previously compiled files to optimize the compilation step
 


### PR DESCRIPTION
I'm not sure what the requirements are to get a place on the README so I figured I'd put it out there anyway. 

This transform is sadly incompatible with the command line usage, but I find it extremely helpful in projects with api-based bundling and I have lots of sometimes expensive transforms running behind a watch task.
