### PR TITLE
allow -x to pass on the expose option

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -54,8 +54,15 @@ module.exports = function (args) {
     // resolve any external files and add them to the bundle as externals
     [].concat(argv.x).concat(argv.external).filter(Boolean)
         .forEach(function (x) {
-            if (/^[\/.]/.test(x)) b.external(path.resolve(process.cwd(), x))
-            else b.external(x)
+            var xs = x.split(':');
+            if (xs.length === 1) {
+                opts = {};
+            } else {
+                x = xs[0];
+                opts = {expose: xs[1]};
+            }
+            if (/^[\/.]/.test(x)) b.external(path.resolve(process.cwd(), x),opts)
+            else b.external(x,opts)
         })
     ;
     


### PR DESCRIPTION
Similar to how you can use -r ./module-file.js:module-name to set the
exposed require name for a module, we should be able to set the exposed
module name for external modules.

This allows the user to require vendor libraries into a bundle using
short names, and to allow access to those libraries using the short
name.

An example using jquery installed with bower might look like:

browserify -r ./bower_components/jquery/jquery.js:jquery -o vendor.js
browserify -x ./bower_components/jquery/jquery.js:jquery app.js
