### PR TITLE
Add support for basedir option passed to insert-module-globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,8 @@ Browserify.prototype.bundle = function (opts, cb) {
         ? insertGlobals(self.files, {
             resolve: self._resolve.bind(self),
             always: opts.insertGlobals,
-            vars: opts.insertGlobalVars
+            vars: opts.insertGlobalVars,
+            basedir: opts.basedir || self._basedir
         })
         : through()
     ;

--- a/test/global.js
+++ b/test/global.js
@@ -46,6 +46,20 @@ test('__filename and __dirname', function (t) {
     });
 });
 
+test('__filename and __dirname with basedir', function (t) {
+    t.plan(2);
+    
+    var b = browserify();
+    b.expose('x', __dirname + '/global/filename.js');
+    b.bundle({ basedir: __dirname }, function (err, src) {
+        var c = {};
+        vm.runInNewContext(src, c);
+        var x = c.require('x');
+        t.equal(x.filename, '/global/filename.js');
+        t.equal(x.dirname, '/global');
+    });
+});
+
 test('process.nextTick', function (t) {
     t.plan(1);
     


### PR DESCRIPTION
I was trying to influence the outgoing filename by setting basedir in the bundle options, but that wasn't working because the option isn't passed to insertGlobals. This PR just adds that option to the insertGlobals call. 
