### PR TITLE
do not hide EMFILE error

### DIFF
--- a/index.js
+++ b/index.js
@@ -554,7 +554,10 @@ Browserify.prototype._resolve = function (id, parent, cb) {
         if (err && !/Cannot find module/.test(err && err.message)
         && self._ignoreMissing == true) {
             return cb(err);
+        } else if (err && err.code === 'EMFILE') {
+            return cb(err);
         }
+
         if (!file && (self._external[id] || self._external[file])) {
             return cb(null, emptyModulePath);
         }


### PR DESCRIPTION
I just finished debugging a very weird case where I ran out of fds and browserify reported that some module simply cannot be found. I changed that behaviour by propagating `EMFILE` up to the user.
