### PR TITLE
Update native-buffer-browserify to 2.0.0 for IE6-8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "crypto-browserify": "~1.0.9",
     "util": "~0.10.1",
     "events": "~1.0.0",
-    "native-buffer-browserify": "~1.2.1",
+    "native-buffer-browserify": "~2.0.0",
     "url": "~0.7.9",
     "https-browserify": "~0.0.0",
     "path-browserify": "~0.0.0",


### PR DESCRIPTION
Summary of changes:
- Works in IE6-8 now! (for real this time!)
- Bundle size reduced by 40%! (down to 37KB from 60KB)
- Firefox performance significantly improved (many orders of magnitude) by removing Proxy implementation

More info: https://github.com/feross/native-buffer-browserify/issues/7
