### PR TITLE
return this in noParse

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ Browserify.prototype.noParse = function(file) {
         if (r) self._noParse.push(r);
         if (--self._pending === 0) self.emit('_ready');
     });
+    return this;
 };
 
 Browserify.prototype.add = function (file) {


### PR DESCRIPTION
Returning `this` in `noParse` to maintain fluent interface
