### PR TITLE
Emit close event on bundle stream with standalone

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,8 +297,7 @@ Browserify.prototype.bundle = function (opts, cb) {
     if (opts.standalone) {
         var output = through();
         p.pipe(concatStream({ encoding: 'string' }, function (body) {
-            output.queue(derequire(body));
-            output.queue(null);
+            output.end(derequire(body));
         }));
         return output;
     }

--- a/test/standalone_events.js
+++ b/test/standalone_events.js
@@ -1,0 +1,25 @@
+var browserify = require('../');
+var test = require('tap').test;
+
+test('standalone bundle close event', {timeout: 1000}, function (t) {
+    t.plan(4);
+
+    var ended = false;
+    var closed = false;
+
+    var b = browserify(__dirname + '/standalone/main.js');
+    b.on('_ready', function() {
+        var r = b.bundle({standalone: 'stand-test'});
+        r.on('end', function() {
+            t.ok(!ended);
+            t.ok(!closed);
+            ended = true;
+        });
+        r.on('close', function() {
+            t.ok(ended);
+            t.ok(!closed);
+            closed = true;
+            t.end();
+        });
+    });
+});


### PR DESCRIPTION
Currently `watchify` does not work with `standalone` option because the bundle stream does not emit `close` event.

When `this.queue(null)` is called `through` emits `end` event but because the stream is also writable it does not get destroyed. Other way to fix it would be to set  `output.writable = false`.

The test got a bit hacky because when `bundle()` is called before `_ready` event the bug does not appear because it gets wrapped into another `through` stream.
