### PR TITLE
Fix outdated copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -29,7 +29,7 @@ buffer_ieee754.js has this license in it:
 
 ----
 
-Copyright (c) 2008, Fair Oaks Labs, Inc.
+Copyright (c) 2014, Fair Oaks Labs, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The copyright year was out of date (2008). Copyright notices must list the current year. This commit updates the listed year to 2014.
