### PR TITLE
Fix syntax highlighting in markdown code block

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -222,7 +222,7 @@ $ browserify -r through -r duplexer -r ./my-file.js:my-module > bundle.js
 
 Then in your page you can do:
 
-``` js
+``` html
 <script src="bundle.js"></script>
 <script>
   var through = require('through');


### PR DESCRIPTION
Fixed html code block that mistakenly was being syntax highlighted as a js code block
