### PR TITLE
Respect ordering of stream entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ Browserify.prototype.require = function (id, opts) {
     var self = this;
     if (isStream(id)) {
         self.files.push(id);
+        if (opts.entry) self._entries.push(id.path);
         return self;
     }
     

--- a/test/multi_entry.js
+++ b/test/multi_entry.js
@@ -1,21 +1,58 @@
 var browserify = require('../');
 var vm = require('vm');
 var test = require('tap').test;
+var fs = require('fs');
 
-test('multi entry', function (t) {
-    t.plan(3);
-    
-    var b = browserify([
+test('entries as string paths', function (t) {
+    var testFiles = [
         __dirname + '/multi_entry/a.js',
-        __dirname + '/multi_entry/b.js'
-    ]);
-    b.add(__dirname + '/multi_entry/c.js');
-    
-    b.bundle(function (err, src) {
-        var c = {
-            times : 0,
-            t : t
-        };
-        vm.runInNewContext(src, c);
+        __dirname + '/multi_entry/b.js',
+        __dirname + '/multi_entry/c.js'
+    ];
+
+    t.test('multi entry', function (t) {
+        t.plan(3);
+
+        var b = browserify([
+            testFiles[0],
+            testFiles[1]
+        ]);
+        b.add(testFiles[2]);
+
+        b.bundle(function (err, src) {
+            var c = {
+                times : 0,
+                t : t
+            };
+            vm.runInNewContext(src, c);
+        });
+    });
+
+
+    // This test should blink if stream order is not respected
+    t.test('entries as streams', function (t) {
+        t.plan(3);
+
+        // transform paths to streams
+        for (var i = 0; i < testFiles.length; i++) {
+            testFiles[i] = fs.createReadStream(testFiles[i]);
+        }
+
+        // commondir blows up with streams and without basedir
+        var opts = {basedir: __dirname + '/multi_entry'}
+
+        var b = browserify([
+            testFiles[0],
+            testFiles[1]
+        ], opts);
+        b.add(testFiles[2]);
+
+        b.bundle(function (err, src) {
+            var c = {
+                times : 0,
+                t : t
+            };
+            vm.runInNewContext(src, c);
+        });
     });
 });


### PR DESCRIPTION
Added streams (`require(stream, {entry: true})`) are not appended to
the internal `_entries` array like their resolved path conterparts.
_entries is used to determine entry indexing in the ouput bundle.
This commit makes sure entry streams are executed in order in the
ouput bundle.
