### PR TITLE
Convert to streams2 readable streams using through2()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var crypto = require('crypto');
 var through = require('through');
+var through2 = require('through2');
 var pipeline = require('stream-combiner');
 var concatStream = require('concat-stream');
 var checkSyntax = require('syntax-error');
@@ -191,11 +192,15 @@ Browserify.prototype.external = function (id, opts) {
         function captureDeps() {
             var d = mdeps(id.files, opts);
             d.on('error', self.emit.bind(self, 'error'));
-            d.pipe(through(write, end));
+            d.pipe(through2.obj(write, end));
             
-            function write (row) { self.external(row.id) }
-            function end () {
+            function write (row, encoding, callback) {
+                self.external(row.id);
+                callback();
+            }
+            function end (callback) {
                 if (--self._pending === 0) self.emit('_ready');
+                callback();
             }
         }
         if (id._pending === 0) return captureDeps();
@@ -253,7 +258,7 @@ Browserify.prototype.bundle = function (opts, cb) {
     if (opts.detectGlobals || opts.insertGlobals) {
         opts.globalTransform = [ function (file) {
             if (self._noParse.indexOf(file) >= 0) {
-                return through();
+                return through2();
             }
             return insertGlobals(file, {
                 always: opts.insertGlobals,
@@ -281,13 +286,14 @@ Browserify.prototype.bundle = function (opts, cb) {
     })(cb);
 
     if (self._pending) {
-        var tr = through();
+        var tr = through2();
         self.on('_ready', function () {
             var b = self.bundle(opts, cb);
             b.on('transform', tr.emit.bind(tr, 'transform'));
             if (!cb) b.on('error', tr.emit.bind(tr, 'error'));
             b.pipe(tr);
         });
+        if (cb) tr.resume();
         return tr;
     }
 
@@ -305,13 +311,14 @@ Browserify.prototype.bundle = function (opts, cb) {
         p.pipe(concatStream({ encoding: 'string' }, function (src) {
             cb(null, opts.standalone ? derequire(src) : src);
         }));
+        p.resume();
     }
     d.on('error', p.emit.bind(p, 'error'));
     d.on('transform', p.emit.bind(p, 'transform'));
     d.pipe(p);
     
     if (opts.standalone) {
-        var output = through();
+        var output = through2();
         p.pipe(concatStream({ encoding: 'string' }, function (body) {
             output.end(derequire(body));
         }));
@@ -391,7 +398,7 @@ Browserify.prototype.deps = function (opts) {
     if (!opts) opts = {};
     
     if (self._pending) {
-        var tr = through();
+        var tr = through2.obj();
         self.on('_ready', function () {
             self.deps(opts).pipe(tr);
         });
@@ -405,14 +412,14 @@ Browserify.prototype.deps = function (opts) {
     var d = mdeps(self.files, opts);
     
     var index = 0;
-    var tr = d.pipe(through(write));
+    var tr = d.pipe(through2.obj(write));
     d.on('error', tr.emit.bind(tr, 'error'));
     d.on('transform', tr.emit.bind(tr, 'transform'));
     return tr;
     
-    function write (row) {
-        if (row.id === excludeModulePath) return;
-        if (self._exclude[row.id]) return;
+    function write (row, encoding, callback) {
+        if (row.id === excludeModulePath) return callback();
+        if (self._exclude[row.id]) return callback();
         
         self.emit('dep', row);
         
@@ -432,7 +439,7 @@ Browserify.prototype.deps = function (opts) {
         }, {});
         
         if (self._expose[row.id]) {
-            this.queue({
+            this.push({
                 id: row.id,
                 exposed: self._expose[row.id],
                 deps: {},
@@ -449,7 +456,7 @@ Browserify.prototype.deps = function (opts) {
 
         // skip adding this file if it is external
         if (self._external[row.id]) {
-            return;
+            return callback();
         }
        
         if (/\.json$/.test(row.id)) {
@@ -462,7 +469,8 @@ Browserify.prototype.deps = function (opts) {
             row.entry = ix >= 0;
         }
         if (ix >= 0) row.order = ix;
-        this.queue(row);
+        this.push(row);
+        callback();
     }
 };
 
@@ -476,7 +484,7 @@ Browserify.prototype.pack = function (opts) {
     var hashes = {}, depList = {}, depHash = {};
     var visited = {};
     
-    var input = through(function (row_) {
+    var input = through2.obj(function (row_, encoding, callback) {
         var row = copy(row_);
         
         if (opts.debug) { 
@@ -502,7 +510,7 @@ Browserify.prototype.pack = function (opts) {
         
         if (/^#!/.test(row.source)) row.source = '//' + row.source;
         var err = checkSyntax(row.source, row.id);
-        if (err) return this.emit('error', err);
+        if (err) return callback(err);
         
         row.id = getId(row);
         
@@ -519,7 +527,8 @@ Browserify.prototype.pack = function (opts) {
         });
         row.deps = deps;
 
-        this.queue(row);
+        this.push(row);
+        callback();
     });
     
     function getId (row) {
@@ -540,46 +549,48 @@ Browserify.prototype.pack = function (opts) {
     
     var first = true;
     var hasExports = Object.keys(self.exports).length;
-    var output = through(write, end);
+    var output = through2(write, end);
     
     var sort = depSorter({ index: true });
 
     input.on('data', function (row) { self.emit('row', row) });
-    return pipeline(through(hasher), sort, input, packer, output);
+    return pipeline(through2.obj(hasher), sort, input, packer, output);
     
-    function write (buf) {
+    function write (buf, encoding, callback) {
         if (first) writePrelude.call(this);
         first = false;
-        this.queue(buf);
+        this.push(buf);
+        callback();
     }
     
-    function end () {
+    function end (callback) {
         if (first) writePrelude.call(this);
         if (opts.standalone) {
-            this.queue(
+            this.push(
                 '\n(' + JSON.stringify(mainModule) + ')'
                 + umd.postlude(opts.standalone)
             );
         }
-        if (opts.debug) this.queue('\n');
-        this.queue(null);
+        if (opts.debug) this.push('\n');
+        callback();
     }
     
     function writePrelude () {
         if (!first) return;
         if (opts.standalone) {
-            return this.queue(umd.prelude(opts.standalone).trim() + 'return ');
+            return this.push(umd.prelude(opts.standalone).trim() + 'return ');
         }
-        if (hasExports) this.queue(
+        if (hasExports) this.push(
             (opts.externalRequireName || 'require') + '='
         );
     }
     
-    function hasher (row) {
+    function hasher (row, encoding, callback) {
         row.hash = hash(row.source);
         depList[row.id] = row.deps;
         depHash[row.id] = row.hash;
-        this.queue(row);
+        this.push(row);
+        callback();
     }
     
     function sameDeps (a, b) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browser-pack": "~2.0.0",
     "deps-sort": "~0.1.1",
     "shell-quote": "~0.0.1",
-    "through": "~2.3.4",
+    "through2": "~0.4.1",
     "duplexer": "~0.1.1",
     "stream-combiner": "~0.0.2",
     "concat-stream": "~1.4.1",
@@ -70,7 +70,8 @@
     "backbone": "~0.9.2",
     "dnode": "~1.0.3",
     "seq": "0.3.3",
-    "coffee-script": "~1.5.0"
+    "coffee-script": "~1.5.0",
+    "through": "~2.3.4"
   },
   "author": {
     "name": "James Halliday",

--- a/test/standalone_events.js
+++ b/test/standalone_events.js
@@ -2,23 +2,17 @@ var browserify = require('../');
 var test = require('tap').test;
 
 test('standalone bundle close event', {timeout: 1000}, function (t) {
-    t.plan(4);
+    t.plan(1);
 
     var ended = false;
-    var closed = false;
 
     var b = browserify(__dirname + '/standalone/main.js');
     b.on('_ready', function() {
         var r = b.bundle({standalone: 'stand-test'});
+        r.resume();
         r.on('end', function() {
             t.ok(!ended);
-            t.ok(!closed);
             ended = true;
-        });
-        r.on('close', function() {
-            t.ok(ended);
-            t.ok(!closed);
-            closed = true;
             t.end();
         });
     });


### PR DESCRIPTION
## Summary

This patch converts all through streams created using _through_ to be streams2 streams using _through2_. I ran into an issue where I expected the stream returned by `bundle()` to buffer data until I read from it (steams2 semantics).
## Example

``` javascript
var fs = require("fs");
var browserify = require("browserify");
var output = require("stream-stream")();

output.write(fs.createReadStream("static.js", { encoding: "utf8" });
output.write(browserify("client.js").bundle());
output.end();
output.pipe(fs.createWriteStream("bundle.js"));
```

The bundle stream emits its data immediately before the _stream-stream_ is ready to read from it. I am interested in hearing if there is a better approach I should be using to concatenate static js to my browserify bundle.

_Note_: This is broken nondeterministically, only when `static.js` is sufficiently large.
## Details

Tests passed as-is except for `test/standalone_events.js`. This is because the test is expecting a `close` event and it seems like streams2 readable streams do not emit one by default nor do they propagate close events from piped streams. I changed this test to note expect a `close` event.

Many tests use `through()` and I did not change those - I moved _through_ to _devDependencies_.
## Things to Review
- Usage of `objectMode` in the right places
- Does anything rely on streams1 semantics (e.g., "auto flowing")? This is kind of an backwards-**incompatible** API change. I added calls to `stream.resume()` to automatically start flowing where it made sense (e.g., when there is a callback given).
- Should a `close` event be emitted?
