### PR TITLE
upgrade insert-module-globals for newline fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "duplexer": "~0.1.1",
     "stream-combiner": "~0.0.2",
     "concat-stream": "~1.4.1",
-    "insert-module-globals": "~3.1.2",
+    "insert-module-globals": "~3.1.3",
     "syntax-error": "~0.1.0",
     "browser-resolve": "~1.2.1",
     "inherits": "~2.0.1",


### PR DESCRIPTION
This prevents parse errors by pulling in fixes from @jwalton to address sources that don't end in newlines, like those from `coffeeify`, which include module globals. Tests continue to pass.
