### PR TITLE
no-builtins: Exclude all builtins from node core

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function Browserify (opts) {
     
     self._builtins = opts.builtins === false ? {} : opts.builtins || builtins;
     if (opts.builtins === false) {
-        Object.keys(builtins).forEach(function (key) {
+        require('builtins').forEach(function (key) {
             self._exclude[key] = true;
         });
     }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "shallow-copy": "0.0.1",
     "subarg": "0.0.1",
     "resolve": "~0.6.1",
-    "glob": "~3.2.8"
+    "glob": "~3.2.8",
+    "builtins": "0.0.2"
   },
   "devDependencies": {
     "tap": "~0.4.0",

--- a/test/no_builtins/main.js
+++ b/test/no_builtins/main.js
@@ -1,2 +1,4 @@
 var fs = require('fs');
+var tls = require('tls');
+
 console.log(fs.readFileSync(__dirname + '/x.txt', 'utf8'));


### PR DESCRIPTION
Currently --no-builtins only excludes those builtins defined in ./lib/builtins - this doesn't work when I want to browserify some node code using tls (to get code coverage working using coverify)
