### PR TITLE
parse vars correctly when using --insert-global-vars

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -2,6 +2,7 @@ var browserify = require('../');
 var path = require('path');
 var spawn = require('child_process').spawn;
 var parseShell = require('shell-quote').parse;
+var insertGlobals = require('insert-module-globals');
 var duplexer = require('duplexer');
 var subarg = require('subarg');
 var glob = require('glob');
@@ -192,10 +193,18 @@ module.exports = function (args) {
         return b;
     }
     
+    var insertGlobalVars;
+    if (argv.igv) {
+        insertGlobalVars = argv.igv.split(',').reduce(function (vars, x) {
+            vars[x] = insertGlobals.vars[x];
+            return vars;
+        }, {});
+    }
+
     var bundleOpts = {
         detectGlobals: argv['detect-globals'] !== false && argv.dg !== false,
         insertGlobals: argv['insert-globals'] || argv.ig,
-        insertGlobalVars: argv.igv ? argv.igv.split(',') : undefined,
+        insertGlobalVars: insertGlobalVars,
         ignoreMissing: argv['ignore-missing'] || argv.im,
         debug: argv['debug'] || argv.d,
         standalone: argv['standalone'] || argv.s

--- a/test/args.js
+++ b/test/args.js
@@ -13,3 +13,17 @@ test('bundle from an arguments array', function (t) {
         t.equal(c.window.XYZ, 2);
     });
 });
+
+test('bundle from an arguments with --insert-global-vars', function (t) {
+    t.plan(2)
+
+    var b = fromArgs([ __dirname + '/global/filename.js', '--insert-global-vars=__filename,__dirname' ]);
+    b.expose('x', __dirname + '/global/filename.js');
+    b.bundle({ basedir: __dirname }, function (err, src) {
+        var c = {};
+        vm.runInNewContext(src, c);
+        var x = c.require('x');
+        t.equal(x.filename, '/global/filename.js');
+        t.equal(x.dirname, '/global');
+    })
+});


### PR DESCRIPTION
Currently `--insert-global-vars` is parsed into an array, while insert-module-globals assumes an object.
So, basically this fixes so that `--insert-global-vars` works as expected
