### PR TITLE
Fix #671, external option doesn't work with node modules

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -115,12 +115,14 @@ module.exports = function (args) {
                 var xs = x.split(':');
                 add(xs[0], { expose: xs[1] });
             }
-            else {
+            else if (/\*/.test(x)) {
                 glob(x, function (err, files) {
                     files.forEach(function (file) {
                         add(file, {});
                     });
                 });
+            } else {
+                add(x, {});
             }
             
             function add (x, opts) {

--- a/test/args.js
+++ b/test/args.js
@@ -13,3 +13,12 @@ test('bundle from an arguments array', function (t) {
         t.equal(c.window.XYZ, 2);
     });
 });
+
+test('external flag for node modules', function(t) {
+  t.plan(1);
+
+  var b = fromArgs([ __dirname + '/external_args/main.js', '-x', 'backbone' ]);
+  b.bundle(function (err, src) {
+      vm.runInNewContext(src, {t: t});
+  });
+});

--- a/test/external_args/main.js
+++ b/test/external_args/main.js
@@ -1,0 +1,10 @@
+try {
+  var Backbone = require('backbone');
+  throw new Error('module included');
+} catch (e) {
+  if (e.message === 'module included') {
+    throw e;
+  } else {
+    t.ok(true);
+  }
+}


### PR DESCRIPTION
Looks like the glob matching returns an empty array if it's not a relative path, so node modules are not excluded as they should be.
