### PR TITLE
Fix bug with --global-transform command line argument

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -147,7 +147,7 @@ module.exports = function (args) {
     
     function addTransform (t, opts) {
         if (typeof t === 'string' || typeof t === 'function') {
-            b.transform(t);
+            b.transform(opts, t);
         }
         else if (t && typeof t === 'object') {
             if (!t._[0] || typeof t._[0] !== 'string') {


### PR DESCRIPTION
Previously the `{ global: true }` opts being passed by `--global-transform` was being lost and thus `--global transform` was behaving the same as a normal `--transform`.
