### PR TITLE
Pass transforms to module-deps in deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,6 +421,7 @@ Browserify.prototype.deps = function (opts) {
     
     opts.modules = self._builtins;
     opts.extensions = self._extensions;
+    opts.transforms = self._transforms;
     
     if (!opts.basedir) opts.basedir = self._basedir;
     var d = mdeps(self.files, opts);


### PR DESCRIPTION
So we don't have to duplicate them in a call to deps. Fixes #600. Fixes #697.
