### PR TITLE
Update to derequire@~0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "deep-equal": "~0.1.0",
     "defined": "~0.0.0",
     "deps-sort": "~0.1.1",
-    "derequire": "~0.6.0",
+    "derequire": "~0.8.0",
     "domain-browser": "~1.1.0",
     "duplexer": "~0.1.1",
     "events": "~1.0.0",


### PR DESCRIPTION
The older version was still using esprima-six, whereas >=0.8 are using esprima-fb :)
