### PR TITLE
Fix syntax highlighting of code block in readme

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -238,7 +238,7 @@ $ browserify -r through -r duplexer -r ./my-file.js:my-module > bundle.js
 
 Then in your page you can do:
 
-``` js
+``` html
 <script src="bundle.js"></script>
 <script>
   var through = require('through');


### PR DESCRIPTION
Changed:
![old highlighting](https://i.cloudup.com/HGGsnHf6OQ.png)
To:
![new highlighting](https://i.cloudup.com/OAGK5yyKFL.png)
