### PR TITLE
Don't load same module multiple times if resolved from differnt paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -509,7 +509,6 @@ Browserify.prototype.pack = function (opts) {
     
     var mainModule;
     var hashes = {}, depList = {}, depHash = {};
-    var visited = {};
     
     var input = through2.obj(function (row_, encoding, callback) {
         var row = copy(row_);
@@ -637,15 +636,7 @@ Browserify.prototype.pack = function (opts) {
             var db = depList[kb];
             
             if (ka === kb) continue;
-            if (ha !== hb) return false;
-            if (visited[da] && visited[db]) {
-                if (!deepEqual(da, db)) return false;
-            }
-            else {
-                visited[da] = true;
-                visited[db] = true;
-                if (!sameDeps(da, db)) return false;
-            }
+            if (ha !== hb || !sameDeps(da, db)) return false;
         }
         return true;
     }


### PR DESCRIPTION
There was an optimization which compared the dependency paths instead of
the hashes if the same modules where compared multiple times. This was
not taking into account that a module might be referenced from multiple
paths.

Removing the optimization solves the issue and does not seem to cause
any noticable performance drops.
- Fixes issue #692
