### PR TITLE
Full zlib module support

### DIFF
--- a/lib/builtins.js
+++ b/lib/builtins.js
@@ -34,4 +34,4 @@ exports.tty = require.resolve('tty-browserify');
 exports.url = require.resolve('url/');
 exports.util = require.resolve('util/util.js');
 exports.vm = require.resolve('vm-browserify');
-exports.zlib = require.resolve('zlib-browserify');
+exports.zlib = require.resolve('browserify-zlib');

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "url": "~0.7.9",
     "util": "~0.10.1",
     "vm-browserify": "~0.0.1",
-    "zlib-browserify": "~0.0.3"
+    "browserify-zlib": "~0.1.1"
   },
   "devDependencies": {
     "backbone": "~0.9.2",

--- a/readme.markdown
+++ b/readme.markdown
@@ -211,7 +211,7 @@ When you `require()` any of these modules, you will get a browser-specific shim:
 * [url](https://npmjs.org/package/url)
 * [util](https://npmjs.org/package/util)
 * [vm](https://npmjs.org/package/vm-browserify)
-* [zlib](https://npmjs.org/package/zlib-browserify)
+* [zlib](https://npmjs.org/package/browserify-zlib)
 
 Additionally if you use any of these variables, they
 [will be defined](https://github.com/substack/insert-module-globals)


### PR DESCRIPTION
I implemented a [replacement module](https://github.com/devongovett/browserify-zlib) for the current zlib module being used by browserify that supports the full Node zlib API. It uses the actual JS zlib code from Node, and passes Node's zlib tests by basically implementing the C++ binding that Node uses on top of [pako](https://github.com/nodeca/pako), which is a direct port of zlib to JS.  This means that the full API is implemented (including streaming, async, sync, etc.), the API and behavior exactly matches Node, and because pako is a direct port of zlib, the output is binary identical to the output produced by Node's zlib module.  Also, pako is way faster than the zlib library being used by the current module (see benchmarks on their repo compared to imaya).  The only things not implemented yet are the `params` method and the `dictionary` option because pako doesn't have the underlying methods for those yet, but I hope to write patches for those soon.  Let me know what you think!
