### PR TITLE
End output with semicolon

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,6 +622,7 @@ Browserify.prototype.pack = function (opts) {
                 + umd.postlude(opts.standalone)
             );
         }
+        this.push(';');
         if (opts.debug) this.push('\n');
         callback();
     }

--- a/test/pack.js
+++ b/test/pack.js
@@ -30,6 +30,14 @@ test('custom packer', function (t) {
         }
     });
     b.bundle(function (err, src) {
-        t.equal(src, '1\n2\n3\n');
+        t.equal(src, '1\n2\n3\n;');
     });
+});
+
+test('end with semicolon', function (t) {
+  t.plan(1);
+  var b = browserify(__dirname + '/entry/main.js');
+  b.bundle(function (err, src) {
+    t.equal(src.charAt(src.length - 1), ';');
+  });
 });


### PR DESCRIPTION
I am in an environment where sometimes the output of browserify is concatenated with other outputs (some being output of browserify, some being other JavaScript). The lack of a terminating semicolon on the output from browserify is causing errors.

Is this okay or do we want to make this an option or push this concern off to consumers?
