### PR TITLE
pass dir as second argument to packageFilter

### DIFF
--- a/index.js
+++ b/index.js
@@ -313,9 +313,9 @@ Browserify.prototype.bundle = function (opts, cb) {
     opts.transformKey = [ 'browserify', 'transform' ];
     
     var parentFilter = opts.packageFilter;
-    opts.packageFilter = function (pkg) {
-        if (parentFilter) pkg = parentFilter(pkg || {});
-        return packageFilter(pkg || {});
+    opts.packageFilter = function (pkg, x) {
+        if (parentFilter) pkg = parentFilter(pkg || {}, x);
+        return packageFilter(pkg || {}, x);
     };
 
     if (cb) cb = (function (f) {


### PR DESCRIPTION
Pass second arg to packageFilter, follow-thru to changes introduced to module-deps in https://github.com/substack/module-deps/commit/a82197229eb00ec8aefa95d12c7f8f00569062fa
