### PR TITLE
exclude missing modules when ignoreMissing is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -725,7 +725,7 @@ Browserify.prototype._resolve = function (id, parent, cb) {
         }
         else if (!file && self._ignoreMissing) {
             self.emit('missing', id, parent);
-            return cb(null, emptyModulePath);
+            return cb(null, excludeModulePath);
         }
         else if (!file) {
             return cb(notFound(id, parent.filename))


### PR DESCRIPTION
This makes so that `require` calls to missing modules now throw instead of returning `{}` when the `--ignore-missing` flag is set, as reported on https://github.com/substack/node-browserify/issues/733.

I believe this behavior better matches the node.js semantics.

I noticed though that through the API there's a consistent distinction between `ignore` and `exclude`. Perhaps it's a better idea to create a `--exclude-missing` flag to make this distinction fully orthogonal across the API?
