### PR TITLE
Update core url dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "timers-browserify": "~1.0.1",
     "tty-browserify": "~0.0.0",
     "umd": "~2.0.0",
-    "url": "~0.7.9",
+    "url": "~0.10.0",
     "util": "~0.10.1",
     "vm-browserify": "~0.0.1"
   },


### PR DESCRIPTION
An updated url module has been pushed to npm.  This version reduces the `npm install browserify` payload by 20MB.

Related to #707.
