### PR TITLE
Use graceful-fs for reading files. Prevent too many open files error (EMFILE).

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var merge = require('xtend');
 var path = require('path');
 var inherits = require('inherits');
 var EventEmitter = require('events').EventEmitter;
-var fs = require('fs');
+var fs = require('graceful-fs');
 var copy = require('shallow-copy');
 
 var emptyModulePath = path.join(__dirname, 'lib/_empty.js');

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "util": "~0.10.1",
     "vm-browserify": "~0.0.1",
     "xtend": "^3.0.0",
-    "process": "^0.7.0"
+    "process": "^0.7.0",
+    "graceful-fs": "~2.0.3"
   },
   "devDependencies": {
     "backbone": "~0.9.2",


### PR DESCRIPTION
Use the `graceful-fs` module (https://github.com/isaacs/node-graceful-fs) to prevent EMFILE error, when requiring many separate files. The error is especially visible on OS X which has a low open file limit.
