### PR TITLE
Update querystring-es3 semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "parents": "~0.0.1",
     "path-browserify": "~0.0.0",
     "punycode": "~1.2.3",
-    "querystring-es3": "0.2.0",
+    "querystring-es3": "~0.2.0",
     "readable-stream": "^1.0.27-1",
     "resolve": "~0.6.1",
     "shallow-copy": "0.0.1",


### PR DESCRIPTION
- Use the `~` range for querystring-es3 to pick up new versions

Closes #764
