### PR TITLE
Allow passing streams to module pack pipeline

### DIFF
--- a/index.js
+++ b/index.js
@@ -638,7 +638,12 @@ Browserify.prototype.pack = function (opts) {
         this.push(row);
         next();
     });
-    return pipeline(through2.obj(hasher), sort, input, emitRows, packer, output);
+
+    var streams = [];
+    if (opts.sourceTransform) streams.push(opts.sourceTransform);
+    streams.push(through2.obj(hasher), sort, input, emitRows, packer, output);
+
+    return pipeline.apply(undefined, streams);
     
     function write (buf, encoding, callback) {
         if (first) writePrelude.call(this);


### PR DESCRIPTION
This PR allows us changing the file tree before compiling. Here is the way I use it;

``` js
b.plugin(function (b) {
     var pack = b.pack;

     b.pack = function (opts) {
       opts.sourceTransform = through(function (row) {
         // change the row
         this.queue(row);
       });

       return pack.call(this, opts);
     };
});
```
