### PR TITLE
Emit 'id' event on the Browserify stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -589,7 +589,7 @@ Browserify.prototype.pack = function (opts) {
         if (err) return callback(err);
         
         var newId = getId(row);
-        this.emit('id', newId, row.id);
+        self.emit('id', newId, row.id);
         row.id = getId(row);
         
         if (row.entry) mainModule = mainModule || row.id;


### PR DESCRIPTION
No one is listening to an 'id' event on this Transform stream, I think it's supposed to be emitted on the Browserify stream.
