### PR TITLE
Don't clobber `ignoreMissing` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,9 +279,9 @@ Browserify.prototype.bundle = function (opts, cb) {
     if (!opts) opts = {};
     if (opts.ignoreMissing === undefined) opts.ignoreMissing = false;
     if (opts.standalone === undefined) opts.standalone = false;
-    
-    self._ignoreMissing = opts.ignoreMissing;
-    
+
+    if (self._ignoreMissing === undefined) self._ignoreMissing = opts.ignoreMissing;
+
     if (cb) cb = (function (f) {
         return function () {
             if (f) f.apply(this, arguments);

--- a/test/ignore_missing.js
+++ b/test/ignore_missing.js
@@ -1,0 +1,34 @@
+var browserify = require('../');
+var test = require('tap').test;
+
+test('ignoreMissing option', function (t) {
+  t.test('on browserify', function(t) {
+    var ignored = browserify({
+      entries: [__dirname + '/ignore_missing/main.js'],
+      ignoreMissing: true
+    });
+
+    ignored.bundle(function(err) {
+      t.ok(!err, "bundle completed with missing file ignored");
+      t.end()
+    });
+  });
+
+  t.test('on .bundle', function(t) {
+    var ignored = browserify(__dirname + '/ignore_missing/main.js');
+
+    ignored.bundle({ignoreMissing: true}, function(err) {
+      t.ok(!err, "bundle completed with missing file ignored");
+      t.end();
+    });
+  });
+
+  test('defaults to false', function (t) {
+    var expected = browserify(__dirname + '/ignore_missing/main.js');
+
+    expected.bundle(function(err) {
+      t.ok(err, 'ignoreMissing was false, an error was raised');
+      t.end();
+    });
+  });
+});

--- a/test/ignore_missing/main.js
+++ b/test/ignore_missing/main.js
@@ -1,0 +1,1 @@
+require('./no_such_file');


### PR DESCRIPTION
`bundle` would clobber the `ignoreMissing` option if you had set it on the original call to `browserify`.  Provided tests ensure the option works at both stages.  I :heart: Browserify.
