### PR TITLE
Fix transform params swap error (Issue #777)

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,10 +349,11 @@ Browserify.prototype.transform = function (opts, t) {
         t = opts;
         opts = {};
     }
-    if (typeof opts === 'string' || typeof opts === 'function') {
+    if ((typeof opts === 'string' || typeof opts === 'function') &&
+        !(typeof t === 'string' || typeof t === 'function')) {
         var t_ = t;
         t = opts;
-        opts = t;
+        opts = t_;
     }
     if (!opts) opts = {};
     if (typeof t === 'string') {


### PR DESCRIPTION
Also, Only swap params in b.transform() if the second param (t) is not already a string or function
