### PR TITLE
Pass `debug` flag through to transform options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,10 @@ Browserify.prototype.transform = function (tr, opts) {
     }
     if (!opts) opts = {};
     
+    opts.debug = 'debug' in opts
+        ? opts.debug
+        : !!self._options.debug;
+
     apply();
     self.on('reset', apply);
     

--- a/test/tr_debug.js
+++ b/test/tr_debug.js
@@ -1,0 +1,36 @@
+var through = require('through2');
+var browserify = require('../');
+var test = require('tap').test;
+var vm = require('vm');
+
+test('--debug passed to transforms', function (t) {
+    var empty = require.resolve('../lib/_empty');
+
+    t.plan(3);
+
+    [true, false].forEach(function(debug) {
+        var b = browserify(empty, { debug: debug });
+
+        b.transform(function(file, opts) {
+            t.equal(opts.debug, debug, 'debug: ' + debug);
+            return through();
+        });
+
+        b.bundle(function (err, src) {
+            if (err) return t.fail(err.message);
+        });
+    });
+
+    var b = browserify(empty, { debug: true });
+
+    b.transform({
+        debug: Infinity
+    }, function(file, opts) {
+        t.equal(opts.debug, Infinity, 'transform arguents are preserved');
+        return through();
+    });
+
+    b.bundle(function(err, src) {
+        if (err) return t.fail(err.message);
+    });
+});


### PR DESCRIPTION
When using the debug option from either the command-line or module API, each transform stream's options will be modified to include `{ debug: true }`.

Likewise, false will be used if browserify is not running in debug mode. If a transform has specified its own debug option that value will be used instead.

I can see this is useful in a number of cases, but for me specifically it's to enable sourcemaps on glslify shaders when `--debug` is enabled.

Thanks!
