### PR TITLE
Fixes issue 796, can't ignore npm modules

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -102,6 +102,8 @@ module.exports = function (args, opts) {
     
     [].concat(argv.ignore).filter(Boolean)
         .forEach(function (i) {
+            b.ignore(i);
+
             b._pending ++;
             glob(i, function (err, files) {
                 if (err) return b.emit('error', err);


### PR DESCRIPTION
After a quick look, I just emulated what the exclude does.  
