### PR TITLE
Turn required relative file paths into absolute ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ Browserify.prototype.require = function (file, opts) {
     }
 
     if(typeof file === 'string' && file.charAt(0) === '.') {
-        file = path.resolve(file);
+        file = '/' + path.relative(basedir, file);
     }
     
     var row = typeof file === 'object'


### PR DESCRIPTION
Entry scripts are showing up with relative paths in source maps, although transforms see an absolute path.

Root cause of https://github.com/ben-ng/minifyify/issues/54, because the file paths that are provided during the transform are absolute, while the file path in the source map is relative.
