### PR TITLE
Add implicit dependency on original module during dedupe

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,6 +475,9 @@ Browserify.prototype._dedupe = function () {
             ;
             row.nomap = true;
         }
+        if (row.dedupeIndex && row.dedupe) {
+            row.indexDeps[row.dedupe] = row.dedupeIndex;
+        }
         this.push(row);
         next();
     });

--- a/test/dedupe-deps.js
+++ b/test/dedupe-deps.js
@@ -1,0 +1,22 @@
+var browserify = require('../');
+var test = require('tap').test;
+
+test('identical content gets deduped and the row gets an implicit dep on the original source', function (t) {
+  t.plan(1)
+
+  var rows = [];
+  browserify()
+    .on('dep', [].push.bind(rows))
+    .require(require.resolve('./dup'), { entry: true })
+    .bundle(check);
+
+  function check(err, src) {
+    if (err) return t.fail(err);
+    var deduped = rows.filter(function (x) { return x.dedupeIndex });
+    var d = deduped[0];
+    var deps = {};
+    deps[d.dedupe] = d.dedupeIndex;
+
+    t.deepEqual(d.deps, deps, "adds implicit dep");
+  }
+})


### PR DESCRIPTION
This change ensures the original module is recorded as a dependency of a deduplicated module.

When modules are deduplicated and dependencies between the duplicate and original are the same, the resulting duplicate module code looks like this:

``` js
module.exports=require(<original-module-index>)
```

Arguably, this implies that there is now a dependency on the original module from the duplicate, but this information was not being recorded.

Previously, plugins that use dependency information (i.e., factor-bundle) were getting an incomplete picture of a row's dependencies if it had been deduplicated. This was causing issues such as substack/factor-bundle#38 and substack/factor-bundle#39.
