### PR TITLE
Preserving bpack.hasExports on reset()

### DIFF
--- a/index.js
+++ b/index.js
@@ -555,7 +555,9 @@ Browserify.prototype._debug = function (opts) {
 
 Browserify.prototype.reset = function (opts) {
     if (!opts) opts = {};
+    var hadExports = this._bpack.hasExports;
     this.pipeline = this._createPipeline(xtend(opts, this._options));
+    this._bpack.hasExports = hadExports;
     this._entryOrder = 0;
     this._bundled = false;
     this.emit('reset');


### PR DESCRIPTION
I went digging to figure out what was causing substack/node-browserify#887 and found that the `hasExports` setting for `browser-pack` is externally managed by browserify under various conditions, including the `b.require()` method.

Using watchify, you call `.bundle()` again on `update` which internally calls `.reset()` to recreate the pipeline, which creates a new `this._bpack` instance.

Because `hasExports` is not set in `this._options`, the `hasExternal` setting never makes it back into the new `_bpack` instance, meaning subsequent bundles behave differently.

I've fixed it by remembering the setting immediately before the pipeline is recreated, and immediately afterwards reapplying the previous value. 

I considered adding it to the `opts` provided to `this._createPipeline` but didn't want to introduce any side effects, the implementation I went with is more consistent with the way `this._bpack.hasExports` is set in all the other cases, so it will now have exactly the same behaviour initially and after any pipeline reset.
