### PR TITLE
Fixed ignore handling with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore IntelliJ files
+*.iml
+atlassian-ide-plugin.xml
+.idea
+node_modules

--- a/index.js
+++ b/index.js
@@ -176,7 +176,16 @@ Browserify.prototype.exclude = function (file, opts) {
 };
 
 Browserify.prototype.ignore = function (file, opts) {
-    this._ignore.push(file);
+    if (!opts) opts = {};
+    var basedir = defined(opts.basedir, process.cwd());
+
+    // Handle relative paths
+    if (file[0] === '.') {
+        this._ignore.push(path.resolve(basedir, file));
+    }
+    else {
+        this._ignore.push(file);
+    }
     return this;
 };
 
@@ -329,6 +338,9 @@ Browserify.prototype._createDeps = function (opts) {
                 }
                 if (self._exclude.indexOf(ex) >= 0) {
                     return cb(null, ex);
+                }
+                if (self._ignore.indexOf(ex) >= 0) {
+                    return cb(null, paths.empty, {});
                 }
             }
             cb(err, file, pkg);

--- a/test/ignore.js
+++ b/test/ignore.js
@@ -16,17 +16,57 @@ test('ignore', function (t) {
 });
 
 test('ignore by package or id', function (t) {
-    t.plan(4);
+    t.plan(3);
   
     var b = browserify();
     b.add(__dirname + '/ignore/by-id.js');
     b.ignore('events');
     b.ignore('beep');
     b.ignore('bad id');
-    b.ignore('./skip.js');
-  
+
     b.bundle(function (err, src) {
         if (err) t.fail(err);
         vm.runInNewContext(src, { t: t });
     });
+});
+
+test('ignore files referenced by relative path', function (t) {
+	// Change the current working directory relative to this file
+	var cwd = process.cwd();
+	process.chdir(__dirname);
+
+	t.plan(1);
+
+	var b = browserify();
+	b.add(__dirname + '/ignore/by-relative.js');
+	b.ignore('./ignore/ignored/skip.js');
+
+	b.bundle(function (err, src) {
+		if (err) t.fail(err);
+		vm.runInNewContext(src, { t: t });
+	});
+
+	// Revert CWD
+	process.chdir(cwd);
+});
+
+test('do not ignore files with relative paths that do not resolve', function (t) {
+	// Change the current working directory to the ignore folder
+	var cwd = process.cwd();
+	process.chdir(__dirname + '/ignore');
+
+	t.plan(2);
+
+	var b = browserify();
+	b.add(__dirname + '/ignore/double-skip.js');
+
+	b.ignore('./skip.js');
+
+	b.bundle(function (err, src) {
+		if (err) t.fail(err);
+		vm.runInNewContext(src, { t: t });
+	});
+
+	// Revert CWD
+	process.chdir(cwd);
 });

--- a/test/ignore/by-id.js
+++ b/test/ignore/by-id.js
@@ -1,4 +1,3 @@
 t.deepEqual(require('events'), {});
 t.deepEqual(require('bad id'), {});
 t.deepEqual(require('beep'), {});
-t.deepEqual(require('./skip.js'), {});

--- a/test/ignore/by-relative.js
+++ b/test/ignore/by-relative.js
@@ -1,0 +1,5 @@
+/**
+ * This test is to check to make sure that files that are ignored do not get
+ * bundled when referenced with a nested relative path.
+ */
+t.deepEqual(require('./relative'), {});

--- a/test/ignore/double-skip.js
+++ b/test/ignore/double-skip.js
@@ -1,0 +1,2 @@
+t.deepEqual(require('./skip.js'), {});
+t.deepEqual(require('./double-skip/index'), {foo: 'bar'});

--- a/test/ignore/double-skip/index.js
+++ b/test/ignore/double-skip/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./skip.js');

--- a/test/ignore/double-skip/skip.js
+++ b/test/ignore/double-skip/skip.js
@@ -1,0 +1,5 @@
+// this module should return something
+
+module.exports = {
+	foo: 'bar'
+};

--- a/test/ignore/ignored/skip.js
+++ b/test/ignore/ignored/skip.js
@@ -1,0 +1,1 @@
+t.fail('this file should have been skipped');

--- a/test/ignore/relative/index.js
+++ b/test/ignore/relative/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../ignored/skip.js');


### PR DESCRIPTION
Addresses issue #896.  I had to modify an existing test as by-id ignoring of relative paths is not possible with this fix (and probably shouldn't be as it causes the bug).
