### PR TITLE
Pass "flags" option to each transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,6 +214,10 @@ Browserify.prototype.transform = function (tr, opts) {
     }
     if (!opts) opts = {};
     
+    opts.flags = 'flags' in opts
+      ? opts.flags
+      : self._options;
+
     apply();
     self.on('reset', apply);
     

--- a/test/tr_flags.js
+++ b/test/tr_flags.js
@@ -1,0 +1,36 @@
+var through = require('through2');
+var browserify = require('../');
+var test = require('tap').test;
+var vm = require('vm');
+
+test('--debug passed to transforms', function (t) {
+    var empty = require.resolve('../lib/_empty');
+
+    t.plan(3);
+
+    [true, false].forEach(function(debug) {
+        var b = browserify(empty, { debug: debug });
+
+        b.transform(function(file, opts) {
+            t.equal(opts.flags.debug, debug, 'debug: ' + debug);
+            return through();
+        });
+
+        b.bundle(function (err, src) {
+            if (err) return t.fail(err.message);
+        });
+    });
+
+    var b = browserify(empty, { debug: true });
+
+    b.transform({
+        flags: Infinity
+    }, function(file, opts) {
+        t.equal(opts.flags, Infinity, 'transform arguents are preserved');
+        return through();
+    });
+
+    b.bundle(function(err, src) {
+        if (err) return t.fail(err.message);
+    });
+});


### PR DESCRIPTION
Essentially, `flags` is set to the value of the bundler's `_options` property.

This should enable more intelligent transform behaviours, for example toggling source maps when `--debug` is supplied through the CLI or module API.
- Closes substack/node-browserify#844
- Fixes hughsk/uglifyify#16
- Fixes hughsk/uglifyify#18

Thanks!
