### PR TITLE
Attempt to dedupe deps when fullPaths is on.

### DIFF
--- a/index.js
+++ b/index.js
@@ -486,6 +486,15 @@ Browserify.prototype._syntax = function () {
 
 Browserify.prototype._dedupe = function () {
     return through.obj(function (row, enc, next) {
+        if (!row.dedupeIndex && row.dedupe) {
+            row.source = 'module.exports=require('
+                + JSON.stringify(row.dedupe)
+                + ')'
+            ;
+            row.deps = {};
+            row.deps[row.dedupe] = row.dedupe;
+            row.nomap = true;
+        }
         if (row.dedupeIndex && row.sameDeps) {
             row.source = 'module.exports=require('
                 + JSON.stringify(row.dedupeIndex)

--- a/test/dedupe-deps.js
+++ b/test/dedupe-deps.js
@@ -20,3 +20,21 @@ test('identical content gets deduped and the row gets an implicit dep on the ori
     t.deepEqual(d.deps, deps, "adds implicit dep");
   }
 })
+
+test('identical content gets deduped with fullPaths', function (t) {
+  t.plan(1)
+
+  var rows = [];
+  browserify({fullPaths: true})
+    .on('dep', [].push.bind(rows))
+    .require(require.resolve('./dup'), { entry: true })
+    .bundle(check);
+
+  function check(err, src) {
+    if (err) return t.fail(err);
+    var deduped = rows.filter(function (x) { return x.dedupe });
+    var d = deduped[0];
+
+    t.deepEqual(d.source, 'module.exports=require('+ JSON.stringify(d.dedupe) + ')', "dedupes content");
+  }
+})


### PR DESCRIPTION
Many front-end modules can't handle being loaded twice. Browserify doesn't dedupe dependencies when you use the `fullPaths` feature and `fullPaths` is necessary for watchify to cache results and quickly rebuild bundles on incremental changes.

This problem is particularly noticeable when trying to `npm link` to dependencies that have redundant dependencies.

This PR coaxes browserify to dedupe dependencies even when fullPaths is on. I'm not sure I understand the different code paths in _dedupe yet so this PR is likely missing some crucial edge cases.
