### PR TITLE
Update source_maps example to fit recent changes

### DIFF
--- a/example/source_maps/build.js
+++ b/example/source_maps/build.js
@@ -4,7 +4,10 @@ var browserify = require('../..'),
     bundlePath = path.join(__dirname, 'js', 'build', 'bundle.js');
 
 browserify()
-    .require(require.resolve('./js/main.js'), { entry: true })
-    .bundle({ debug: true })
+    .require(require.resolve('./js/main.js'), { 
+    	entry: true, 
+    	debug: true  
+    })
+    .bundle()
     .on('error', function (err) { console.error(err); })
     .pipe(fs.createWriteStream(bundlePath));


### PR DESCRIPTION
```
Error: bundle() no longer accepts option arguments.
```
