### PR TITLE
Make source map's "sourceFile"s relative to "basedir"

### DIFF
--- a/index.js
+++ b/index.js
@@ -578,10 +578,11 @@ Browserify.prototype._emitDeps = function () {
 };
 
 Browserify.prototype._debug = function (opts) {
+    var basedir = defined(opts.basedir, process.cwd());
     return through.obj(function (row, enc, next) {
         if (opts.debug) {
             row.sourceRoot = 'file://localhost';
-            row.sourceFile = row.file.replace(/\\/g, '/');
+            row.sourceFile = path.relative(basedir, row.file);
         }
         this.push(row);
         next();


### PR DESCRIPTION
The extra path info adds noise when debugging and makes debug builds non-deterministic. `browser-pack` should also have it's `preludePath` be relative to the `basedir` (PR coming soon), though it's an easy override by passing in opts with `{ preludePath: 'whatever' }`.
