### PR TITLE
Add type check for `opts.basedir`

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ function Browserify (files, opts) {
     self._options = opts;
     if (opts.noParse) opts.noparse = opts.noParse;
     
+    if (opts.basedir !== undefined && typeof opts.basedir !== 'string') {
+        throw new Error('opts.basedir must be either undefined or a string.');
+    }
+    
     self._external = [];
     self._exclude = [];
     self._ignore = [];


### PR DESCRIPTION
If you pass a non-undefined, non-string to opts.basedir, the error you get out looks like:

```
TypeError: Arguments to path.resolve must be strings
    at exports.resolve (path.js:313:15)
    at exports.relative (path.js:370:20)
    at Browserify._createDeps.mopts.resolve (/Users/forbeslindesay/GitHub/browserify-middleware/node_modules/browserify/index.js:349:37)
    at /Users/forbeslindesay/GitHub/browserify-middleware/node_modules/browserify/node_modules/browser-resolve/index.js:188:13
    at module.exports.cb (/Users/forbeslindesay/GitHub/browserify-middleware/node_modules/browserify/node_modules/resolve/lib/async.js:38:25)
    at module.exports.cb (/Users/forbeslindesay/GitHub/browserify-middleware/node_modules/browserify/node_modules/resolve/lib/async.js:65:30)
    at module.exports.isFile (/Users/forbeslindesay/GitHub/browserify-middleware/node_modules/browserify/node_modules/resolve/lib/async.js:23:18)
    at Object.oncomplete (fs.js:107:15)
```

Which took me a while to figure out.  It would be nice to just check it in the constructor of browserify.
