### PR TITLE
Document internal require resolving. Closes #913.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -55,6 +55,11 @@ recursive walk of the `require()` graph using
 To use this bundle, just toss a `<script src="bundle.js"></script>` into your
 html!
 
+**Note:** browserify resolves internal requires in the application, unlike node.
+This means you should use `require(path.join(__dirname, 'foo.js'))` wherever you 
+would use `require('./foo.js')` in files that aren't in the same directory as 
+the root file.
+
 # install
 
 With [npm](http://npmjs.org) do:


### PR DESCRIPTION
browserify resolves requires within an application, unlike node. Since most people don't know this, they run into errors when they try to do stuff like this:

``` javascript

// abc/foo.js

var bar = require('./lib/bar.js');

```

``` javascript

// abc/lib/bar.js

// this would work with node because abc/lib/baz.js exists
// but browserify resolves the path and complains that abc/baz.js doesn't exist
var baz = require('./baz.js');

module.exports = baz;

```

Everyone is therefore forced to do this:

``` javascript
var baz = require(path.join(__dirname, 'baz.js'));
```

Obviously, that's a better (and safer) practice, but people are too used to node's relative-to-__dirname requires. That's why I decided to just document this instead of changing browserify.

(Also, documenting it takes less effort :))

This should fix issue #913.
