### PR TITLE
allow win32 file path in require

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ Browserify.prototype.require = function (file, opts) {
     
     var row = typeof file === 'object'
         ? xtend(file, opts)
-        : (/^[\/.]/.test(file)
+        : (/^[\/.]|^[a-z,A-Z]:/.test(file)
             ? xtend(opts, { file: file })
             : xtend(opts, { id: expose || file })
         )


### PR DESCRIPTION
re allow browserify to accept win32 file path in `require(file, opts)` when working with multiple drives.
For more detail: https://gist.github.com/peutetre/ab74062c2bb14f49889f
