### PR TITLE
Added failing test case for transforming required code

### DIFF
--- a/test/require_transform.js
+++ b/test/require_transform.js
@@ -1,0 +1,21 @@
+var browserify = require('../');
+var vm = require('vm');
+var test = require('tap').test;
+var through = require('through2');
+
+test('require transform', function(t) {
+    t.plan(1);
+
+    var b = browserify();
+    b.transform(function(file) {
+        return through(function(buf, enc, next) {
+            this.push(String(buf).replace(/NORMAL/g, 'TRANSFORMED'));
+            next();
+        });
+    });
+    b.require(__dirname + '/require_transform/main.js', { expose: 'MAIN' });
+    b.bundle(function(err, src) {
+        src += "require('MAIN')();";
+        vm.runInNewContext(src, { t: t });
+    });
+});

--- a/test/require_transform/main.js
+++ b/test/require_transform/main.js
@@ -1,0 +1,5 @@
+var TEST = 'NORMAL';
+
+module.exports = function() {
+    t.equal(TEST, 'TRANSFORMED');
+};


### PR DESCRIPTION
When requiring a file for a bundle it doesn't get passed through any transforms. Have attached a failing test case for this but I'm not sure how to fix it. 

Supposed to have been fixed in 6.0.3 (https://github.com/substack/node-browserify/issues/855)