### PR TITLE
Rename option to 'noParse' for consistency with module-deps

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -24,7 +24,7 @@ module.exports = function (args, opts) {
             igv: 'insert-global-vars',
             d: 'debug',
             s: 'standalone',
-            noparse: [ 'noParse', 'noparse' ],
+            noParse: [ 'noparse' ],
             'full-paths': [ 'fullpaths', 'fullPaths' ],
             r: 'require',
             u: 'exclude',
@@ -71,7 +71,7 @@ module.exports = function (args, opts) {
 
     var ignoreTransform = argv['ignore-transform'] || argv.it;
     var b = browserify(xtend({
-        noparse: argv.noparse,
+        noParse: Array.isArray(argv.noParse) ? argv.noParse : [argv.noParse],
         extensions: [].concat(argv.extension).filter(Boolean),
         ignoreTransform: [].concat(ignoreTransform).filter(Boolean),
         entries: entries,

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function Browserify (files, opts) {
     else opts = xtend(files, opts);
     
     self._options = opts;
-    if (opts.noParse) opts.noparse = opts.noParse;
+    if (opts.noparse) opts.noParse = opts.noparse;
     
     if (opts.basedir !== undefined && typeof opts.basedir !== 'string') {
         throw new Error('opts.basedir must be either undefined or a string.');
@@ -427,8 +427,8 @@ Browserify.prototype._createDeps = function (opts) {
     function globalTr (file) {
         if (opts.detectGlobals === false) return through();
         
-        if (opts.noparse === true) return through();
-        var no = [].concat(opts.noparse).filter(Boolean);
+        if (opts.noParse === true) return through();
+        var no = [].concat(opts.noParse).filter(Boolean);
         if (no.indexOf(file) >= 0) return through();
         if (no.map(function (x){return path.resolve(x)}).indexOf(file)>=0){
             return through();

--- a/readme.markdown
+++ b/readme.markdown
@@ -356,7 +356,7 @@ For each `file` in `files`, if `file` is a stream, its contents will be used.
 You should use `opts.basedir` when using streaming files so that relative
 requires will know where to resolve from.
 
-`opts.noparse` is an array which will skip all require() and global parsing for
+`opts.noParse` is an array which will skip all require() and global parsing for
 each file in the array. Use this for giant libs like jquery or threejs that
 don't have any requires or node-style globals but take forever to parse.
 


### PR DESCRIPTION
- Pass the `--noparse` option from the command line to `module-deps`
- `noParse` option for `browserify` implies option for `module-deps`
- Retains `opts.noparse` for backwards compatibility
