### PR TITLE
bump readable-stream to fix circular dep error

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "process": "^0.8.0",
     "punycode": "~1.2.3",
     "querystring-es3": "~0.2.0",
-    "readable-stream": "^1.0.27-1",
+    "readable-stream": "^1.0.33-1",
     "resolve": "~0.7.1",
     "shallow-copy": "0.0.1",
     "shasum": "^1.0.0",


### PR DESCRIPTION
This looks like it changes nothing, but this tells npm>2 to actually
pull in the `-1` version of readable-stream.

See: https://github.com/isaacs/readable-stream/pull/95
