### PR TITLE
ignoreTransform to check for pkg.browserify.transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,9 @@ function Browserify (files, opts) {
 
     var ignoreTransform = [].concat(opts.ignoreTransform).filter(Boolean);
     self._filterTransform = function(tr) {
+        if (Array.isArray(tr)) {
+            return ignoreTransform.indexOf(tr[0]) === -1;
+        }
         return ignoreTransform.indexOf(tr) === -1;
     }
     


### PR DESCRIPTION
There is an edge case where ignoreTransform will not work if your package.json specify transforms in an array format.

```
    "browserify": {
        "transform": [
            ["reactify", {
                "es6": true
            }],
            "bulkify", ["browserify-istanbul", {
                "ignore": ["**/*/*.json"]
            }]
        ]
    }
```

This change checks if it is an array and extract the index0 to check for the name of the transform.
