### PR TITLE
Fix readme b.transform arguments order

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -474,7 +474,7 @@ Prevent the module name or file at `file` from showing up in the output bundle.
 If your code tries to `require()` that file it will throw unless you've provided
 another mechanism for loading it.
 
-## b.transform(opts={}, tr)
+## b.transform(tr, opts={})
 
 Transform source code before parsing it for `require()` calls with the transform
 function or module name `tr`.


### PR DESCRIPTION
The arguments for `b.transform` were reversed in the readme file, it should be `b.transform(transform, options)`, not `b.transform(options, transform)`.
