### PR TITLE
expose property doesn't work with fullPaths enabled (fixes #850)

### DIFF
--- a/index.js
+++ b/index.js
@@ -597,6 +597,11 @@ Browserify.prototype._label = function (opts) {
         if (row.indexDeps) row.deps = row.indexDeps || {};
         
         Object.keys(row.deps).forEach(function (key) {
+            if (self._expose[key]) {
+                row.deps[key] = key;
+                return;
+            }
+
             var afile = path.resolve(path.dirname(row.file), key);
             var rfile = '/' + path.relative(basedir, afile);
             if (self._external.indexOf(rfile) >= 0) {

--- a/test/entry/needs_three.js
+++ b/test/entry/needs_three.js
@@ -1,0 +1,1 @@
+require("three");

--- a/test/entry/package.json
+++ b/test/entry/package.json
@@ -1,0 +1,5 @@
+{
+  "browser": {
+    "three": "./three.js"
+  }
+}

--- a/test/entry/three.js
+++ b/test/entry/three.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/test/full_paths.js
+++ b/test/full_paths.js
@@ -1,6 +1,7 @@
 var unpack = require('browser-unpack');
 var browserify = require('../');
 var test = require('tap').test;
+var vm = require('vm');
 
 var deps = [
     __dirname + '/entry/main.js',
@@ -34,6 +35,23 @@ test('fullPaths disabled', function (t) {
     b.bundle(function (err, src) {
         unpack(src).forEach(function(dep) {
             t.equal(deps.indexOf(dep.id), -1, 'full path name no longer available');
+        });
+    });
+});
+
+test('fullPaths enabled, with custom exposed dependency name', function (t) {
+    t.plan(1);
+
+    var b = browserify({
+        entries: [__dirname + '/entry/needs_three.js'],
+        fullPaths: true
+    });
+
+    b.require(__dirname + '/entry/three.js', { expose: 'three' });
+
+    b.bundle(function (err, src) {
+        t.doesNotThrow(function () {
+            vm.runInNewContext(src, { console: console, t: t });
         });
     });
 });


### PR DESCRIPTION
If I set `fullPaths: true` on a bundle (which is required by watchify), and also use `expose` on one of the modules in that bundle, the full path clobbers the exposed name and anything that requires the exposed name throws an exception to the effect of `Error: Cannot find module '/foo/bar/baz'` (i.e. the full path).
