### PR TITLE
Don’t leak full path to source in deduped deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -569,8 +569,8 @@ Browserify.prototype._dedupe = function () {
             ;
             row.nomap = true;
         }
-        if (row.dedupeIndex && row.dedupe && row.indexDeps) {
-            row.indexDeps[row.dedupe] = row.dedupeIndex;
+        if (row.dedupeIndex && row.indexDeps) {
+            row.indexDeps.dup = row.dedupeIndex;
         }
         this.push(row);
         next();

--- a/test/dedupe-deps.js
+++ b/test/dedupe-deps.js
@@ -14,10 +14,8 @@ test('identical content gets deduped and the row gets an implicit dep on the ori
     if (err) return t.fail(err);
     var deduped = rows.filter(function (x) { return x.dedupeIndex });
     var d = deduped[0];
-    var deps = {};
-    deps[d.dedupe] = d.dedupeIndex;
 
-    t.deepEqual(d.deps, deps, "adds implicit dep");
+    t.deepEqual(d.deps, { 'dup': d.dedupeIndex }, "adds implicit dep");
   }
 })
 


### PR DESCRIPTION
Fixes #951.

When `fullPaths` is `false`, the important part of the implicit dependency is `row.dedupeIndex`, which must be set as a value in `row.deps`. The key doesn't actually matter, so I chose `dup` because it's short and descriptive enough.

When `fullPaths` is `true`, these dependencies between deduplicated source and original source are already tracked.

This fixes #951 because `row.dedupe` contained the full path to the original source file and it was being used as the key in `deps`, which would leak full paths into the output bundle.
