### PR TITLE
allow custom resolve function

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ function Browserify (files, opts) {
     self._pending = 0;
     self._entryOrder = 0;
     self._ticked = false;
+    self._delegateResolve = opts.resolve || bresolve;
 
     var ignoreTransform = [].concat(opts.ignoreTransform).filter(Boolean);
     self._filterTransform = function(tr) {
@@ -377,7 +378,7 @@ Browserify.prototype._createDeps = function (opts) {
     mopts.resolve = function (id, parent, cb) {
         if (self._ignore.indexOf(id) >= 0) return cb(null, paths.empty, {});
         
-        bresolve(id, parent, function (err, file, pkg) {
+        self._delegateResolve(id, parent, function (err, file, pkg) {
             if (file && self._ignore.indexOf(file) >= 0) {
                 return cb(null, paths.empty, {});
             }

--- a/readme.markdown
+++ b/readme.markdown
@@ -422,8 +422,9 @@ as the `opts.vars` parameter.
 `opts.externalRequireName` defaults to `'require'` in `expose` mode but you can
 use another name.
 
+With `opts.resolve` you can pass in a custom resolve function which has to apply to the [browser-resolve API](https://github.com/defunctzombie/node-browser-resolve#api). Otherwise [browser-resolve](https://npmjs.org/package/browser-resolve) is used for resolving.
 Note that if files do not contain javascript source code then you also need to
-specify a corresponding transform for them.
+specify a corresponding transform for them. 
 
 All other options are forwarded along to
 [module-deps](https://npmjs.org/package/module-deps)


### PR DESCRIPTION
Allow a custom function to resolve require calls.
This functionality was present until version 4. Module-deps still supports it, but browserify does not pass the option.
