### PR TITLE
Fix exposed requires being persisted across bundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -440,7 +440,7 @@ Browserify.prototype._createDeps = function (opts) {
     else if (opts.builtins && typeof opts.builtins === 'object') {
         mopts.modules = opts.builtins;
     }
-    else mopts.modules = builtins;
+    else mopts.modules = copy(builtins);
     
     Object.keys(builtins).forEach(function (key) {
         if (!has(mopts.modules, key)) self._exclude.push(key);

--- a/test/require_expose.js
+++ b/test/require_expose.js
@@ -1,0 +1,27 @@
+var browserify = require('../');
+var test = require('tap').test;
+var vm = require('vm');
+
+test('exposed modules do not leak across bundles', function (t) {
+    var bundle1, bundle2;
+
+    bundle1 = browserify();
+    bundle1.add(__dirname + '/require_expose/main.js');
+    bundle1.require(__dirname + '/require_expose/some_dep.js', { expose: 'foo' });
+
+    bundle1.bundle(function (err, src) {
+        if (err) t.fail(err);
+
+        var c = {};
+        vm.runInNewContext(src, c);
+        t.equal(c.foo, 'some_dep');
+
+        bundle2 = browserify();
+        bundle2.add(__dirname + '/require_expose/main.js');
+
+        bundle2.bundle(function (err) {
+            t.ok(err && err.message.match(/Cannot find module 'foo'/), 'should fail with missing module');
+            t.end();
+        });
+    });
+});

--- a/test/require_expose/main.js
+++ b/test/require_expose/main.js
@@ -1,0 +1,1 @@
+foo = require('foo');

--- a/test/require_expose/some_dep.js
+++ b/test/require_expose/some_dep.js
@@ -1,0 +1,1 @@
+module.exports = 'some_dep';


### PR DESCRIPTION
As mentioned in the comments on issue #908 https://github.com/substack/node-browserify/issues/908#issuecomment-55956552, `expose`d files were being persisted across calls to browserify. I tracked this down to a leak where modules were being appended to the (module) global builtins object. Fixed with a test, though I'm not sure if you want a test for such a fine grained bug, so feel free to remove it, but it does demonstrate the failure & subsequent pass with this fix.