### PR TITLE
Allow modules to be bundled via local paths and globally (`expose`) at the same time

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ Browserify.prototype.require = function (file, opts) {
         row.id = expose || file;
     }
     if (expose || !row.entry) {
-        this._expose[row.id] = file;
+        this._expose[row.id] = path.resolve(basedir, file);
     }
     if (opts.external) return this.external(file, opts);
     if (row.entry === undefined) row.entry = false;

--- a/test/multi_require.js
+++ b/test/multi_require.js
@@ -1,0 +1,16 @@
+var browserify = require('../');
+var test = require('tap').test;
+var vm = require('vm');
+
+test('require same file locally and globally', function (t) {
+    t.plan(1);
+
+    var b = browserify(__dirname + '/multi_require/main.js');
+    b.require('./multi_require/a.js', {expose: 'a'});
+
+    b.bundle(function (err, src) {
+        var c = {t: t};
+        vm.runInNewContext(src, c);
+        t.end()
+    });
+});

--- a/test/multi_require/a.js
+++ b/test/multi_require/a.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return 'a';
+}

--- a/test/multi_require/main.js
+++ b/test/multi_require/main.js
@@ -1,0 +1,4 @@
+var localA = require('./a.js');
+var globalA = require('a');
+
+t.equal(localA, globalA);


### PR DESCRIPTION
Fixes #1020 and potentially #935 (unverified). Added minimal test case and fix but open to revisiting it if there is a better approach.
