### PR TITLE
Allow requiring module locally and globally with `fullPaths=true`

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,11 @@ Browserify.prototype.require = function (file, opts) {
         )
     ;
     if (!row.id) {
-        row.id = expose || file;
+        if (!self._options.fullPaths) {
+            row.id = expose || file;
+        } else {
+            row.id = path.resolve(basedir, file)
+        }
     }
     if (expose || !row.entry) {
         this._expose[row.id] = path.resolve(basedir, file);

--- a/test/multi_require_fullpaths.js
+++ b/test/multi_require_fullpaths.js
@@ -1,0 +1,20 @@
+var browserify = require('../');
+var test = require('tap').test;
+var vm = require('vm');
+
+test(
+  'require same file locally and globally with `fullPaths=true`', function (t) {
+    t.plan(1);
+
+    var b = browserify({
+      entries: __dirname + '/multi_require/main.js',
+      fullPaths: true
+    });
+    b.require('./multi_require/a.js', {expose: 'a'});
+
+    b.bundle(function (err, src) {
+        var c = {t: t};
+        vm.runInNewContext(src, c);
+        t.end()
+    });
+});


### PR DESCRIPTION
This fixes #1020 in conjunction with `watchify` which uses `fullPaths=true`.

**Update:** Turns out this breaks external global access to `require('a')`, e.g. an HTML page with `var a = require('a');` as `a` is now only indexed via `/absolute/path/to/multi_require/a.js`. Related to: https://github.com/substack/watchify/commit/3358625695ad17d4dc3ece639fd7b70c0693d743#commitcomment-9049286

Do you have any ideas on how to restore this behavior from Browserify 4.x/Watchify 0.10.x?

/cc @gscottolson @tarajane