### PR TITLE
use buffer 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "browser-pack": "^3.2.0",
     "browser-resolve": "^1.3.0",
     "browserify-zlib": "~0.1.2",
-    "buffer": "^2.3.0",
+    "buffer": "^3.0.0",
     "builtins": "~0.0.3",
     "commondir": "0.0.1",
     "concat-stream": "~1.4.1",


### PR DESCRIPTION
New Buffer major version: 3.0.0

It has some breaking changes, but they improve compatibility with node!
The whole node buffer test suite passes now, thanks to @jessetane!
- toString('ascii') and slice('ascii') work correctly (strip off high order bits)
- correct exception types thrown (RangeError instead of TypeError in many places)
- do not encode partial code units to utf16
- do not encode partial or invalid code points to utf8
- copy() correctly returns length
