### PR TITLE
Use assert 1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "JSONStream": "~0.8.3",
-    "assert": "~1.1.0",
+    "assert": "~1.3.0",
     "browser-pack": "^3.2.0",
     "browser-resolve": "^1.3.0",
     "browserify-zlib": "~0.1.2",


### PR DESCRIPTION
[assert](https://www.npmjs.com/package/assert) 1.3.0 has released.
There are compatible changes.

* 1.2.0: fix deepEqual bug about arguments ordering (https://github.com/defunctzombie/commonjs-assert/pull/6)
* 1.3.0: fix deepEqual broken in next Chrome 40 and Firefox 35 (https://github.com/defunctzombie/commonjs-assert/pull/7)

Especially 1.3.0 is necessary before Chrome 40 and Firefox 35 release.