### PR TITLE
adds a failing test to show that aliasing things from node_modules is broken 

### DIFF
--- a/test/require_alias.js
+++ b/test/require_alias.js
@@ -1,0 +1,12 @@
+var browserify = require('../');
+var tr = require('tr');
+var test = require('tap').test;
+
+test('require a node module with an expose property', function (t) {
+  var b = browserify();
+  b.require('tr', {expose: 'something'});
+  b.bundle(function (err, src) {
+    t.ok(src, "bundle should not break because the module is exposed as something else"); 
+    t.end();
+  });
+});


### PR DESCRIPTION
browserify should not break when you try to alias a package from inside `node_modules` this pull request adds a failing test to demonstrate that this is happening. 