### PR TITLE
Remove redundant conditional assignment.

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,6 @@ Browserify.prototype.require = function (file, opts) {
                 id: id
             };
             if (rec.entry) rec.order = order;
-            if (rec.transform === false) rec.transform = false;
             self.pipeline.write(rec);
             
             if (-- self._pending === 0) self.emit('_ready');


### PR DESCRIPTION
This conditional assignment appears to serve no purpose. Is it perhaps supposed to be `if (opts.transform === false) rec.transform = false;` like for the `! isStream(file)` code path later in the function? After either changing it to that or deleting it, all tests still pass and I'm not familiar enough with browserify's internals to know what role those properties are supposed to play (I just noticed the line while debugging something else).