### PR TITLE
Properly resolve absolute path of exposed module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ Browserify.prototype.require = function (file, opts) {
         row.id = expose || file;
     }
     if (expose || !row.entry) {
-        this._expose[row.id] = path.resolve(basedir, file);
+        this._expose[row.id] = resolve.sync(file, {basedir: basedir});
     }
     if (opts.external) return this.external(file, opts);
     if (row.entry === undefined) row.entry = false;


### PR DESCRIPTION
The change in #1033 is flawed. And the test coverage for requires is inadequate.

See #1039 (part 1). A broken bundle is generated when doing something like...

```js
// bundle.js
browserify('./src/a')
  .require('./src/b');

// src/a.js
require('./b');

// src/b.js
// I'm the file being required
```
...because the code in #1033 essentially does...

```js
this._expose[row.id] = '/somedir/src/b';
```
...which leads to a mismatch here...

https://github.com/substack/deps-sort/blob/c61e515015a0f8392c1b07530877084b6c411cb7/index.js#L72

...because there should be an entry `index['/somedir/src/b.js']`, but instead there's `index['/somedir/src/b']`.

I'm not 100% sure this pull request completely and correctly solves the problem for all cases, but it does solve it for the scenario in #1039 and is a step in the right direction. That this apparently used to work (according to @gasi in #1033) and that #1033 was merged as a fix underscores the need for better and more comprehensive tests around this functionality.