### PR TITLE
Resolve pathnames of exposed modules more efficiently.

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,28 +151,21 @@ Browserify.prototype.require = function (file, opts) {
         row.id = expose || file;
     }
     if (expose || !row.entry) {
-        self._pending ++;
-        resolve(file, { basedir: basedir }, function (err, res) {
-            if (err) return self.emit('error', err);
-            self._expose[row.id] = res;
-            write();
-            if (-- self._pending === 0) self.emit('_ready');
-        });
+        // Make this available to mdeps so that it can assign the value when it
+        // resolves the pathname.
+        row.expose = row.id;
     }
-    else write();
-    
-    function write () {
-        if (opts.external) return self.external(file, opts);
-        if (row.entry === undefined) row.entry = false;
-        
-        if (!row.entry && self._options.exports === undefined) {
-            self._bpack.hasExports = true;
-        }
-        
-        if (row.entry) row.order = self._entryOrder ++;
-        if (opts.transform === false) row.transform = false;
-        self.pipeline.write(row);
+
+    if (opts.external) return self.external(file, opts);
+    if (row.entry === undefined) row.entry = false;
+
+    if (!row.entry && self._options.exports === undefined) {
+        self._bpack.hasExports = true;
     }
+
+    if (row.entry) row.order = self._entryOrder ++;
+    if (opts.transform === false) row.transform = false;
+    self.pipeline.write(row);
     return self;
 };
 

--- a/index.js
+++ b/index.js
@@ -386,7 +386,10 @@ Browserify.prototype._createDeps = function (opts) {
     var self = this;
     var mopts = copy(opts);
     var basedir = defined(opts.basedir, process.cwd());
-    
+
+    // Let mdeps populate these values since it will be resolving file paths
+    // anyway.
+    mopts.expose = this._expose;
     mopts.extensions = [ '.js', '.json' ].concat(mopts.extensions || []);
     self._extensions = mopts.extensions;
     


### PR DESCRIPTION
This is a followup to #1059. After I submitted that, I was working on an async version, which I didn't have ready yet when you pushed your async implementation, @substack. Then I realized that I don't think it's necessary to even do the resolution in browserify, because it looks like module-deps already does it, before anything else needs access to it.

This changeset relies on related changes to module-deps (substack/module-deps/pull/65).

This may have some rough edges that need to be smoothed out.

* This currently falls down when doing:

```js
b.require('./somefile');
```

Whereas this works:

```js
b.require('./somefile', {expose: 'whatever'});
```

In the former case it leads module-deps to mark the file as builtin which causes transforms not to be run on it. I didn't know that, because tests were passing. I didn't discover it until debugging #1074. One solution would be to set a different prop on the object in `b.require()`, e.g. `exposeAs` instead of `expose`, but that seems kind of silly. I haven't had the chance to do it yet, but I think it would be good to take a closer look at how module-deps is handling that scenario and see if there isn't a correction needed there.

* Further changes may be needed to properly support external modules, but I'll need feedback on #1076 for that.