### PR TITLE
resolve exposed files with browser-resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ Browserify.prototype.require = function (file, opts) {
     }
     if (expose || !row.entry) {
         self._pending ++;
-        resolve(file, { basedir: basedir }, function (err, res) {
+        bresolve(file, { basedir: basedir }, function (err, res) {
             if (err) return self.emit('error', err);
             self._expose[row.id] = res;
             write();

--- a/test/expose_browser_entry.js
+++ b/test/expose_browser_entry.js
@@ -1,0 +1,14 @@
+var browserify = require('../');
+var test = require('tap').test;
+
+test('expose a browser entry', function (t) {
+    t.plan(1);
+
+    var b = browserify({
+        basedir: __dirname + '/expose_browser_entry'
+    });
+    b.require('browser-field-entry');
+    b.bundle(function (err) {
+        t.ifError(err);
+    });
+});

--- a/test/expose_browser_entry/package.json
+++ b/test/expose_browser_entry/package.json
@@ -1,0 +1,5 @@
+{
+  "browser": {
+    "browser-field-entry": "./x.js"
+  }
+}

--- a/test/expose_browser_entry/x.js
+++ b/test/expose_browser_entry/x.js
@@ -1,0 +1,1 @@
+module.exports = 3;


### PR DESCRIPTION
fixes #1072 

Could previously `b.require()` names from the local package.json's _browser_ entry.

If this is desired behaviour (these entries can also be `b.external()`'d.), this restores it along with a simple test.