### PR TITLE
Add pendReady() to factor out repetitive code and facilitate use of the mechanism in plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,13 +148,11 @@ Browserify.prototype.require = function (file, opts) {
         row.id = expose || file;
     }
     if (expose || !row.entry) {
-        self._pending ++;
-        resolve(file, { basedir: basedir }, function (err, res) {
+        resolve(file, { basedir: basedir }, this.pendReady(function (err, res) {
             if (err) return self.emit('error', err);
             self._expose[row.id] = res;
             write();
-            if (-- self._pending === 0) self.emit('_ready');
-        });
+        }));
     }
     else write();
     

--- a/index.js
+++ b/index.js
@@ -111,9 +111,8 @@ Browserify.prototype.require = function (file, opts) {
     }
     
     if (isStream(file)) {
-        self._pending ++;
         var order = self._entryOrder ++;
-        file.pipe(concat(function (buf) {
+        file.pipe(concat(this.pendReady(function (buf) {
             var filename = opts.file || file.file || path.join(
                 basedir,
                 '_stream_' + order + '.js'
@@ -134,9 +133,7 @@ Browserify.prototype.require = function (file, opts) {
             if (rec.entry) rec.order = order;
             if (rec.transform === false) rec.transform = false;
             self.pipeline.write(rec);
-            
-            if (-- self._pending === 0) self.emit('_ready');
-        }));
+        })));
         return this;
     }
     

--- a/index.js
+++ b/index.js
@@ -741,6 +741,24 @@ Browserify.prototype.bundle = function (cb) {
     return this.pipeline;
 };
 
+// Increment _pending and wrap the callback to decrement on execution and emit
+// _ready if appropriate. In other words, make the readyness of the pipeline
+// pending on execution of cb.
+Browserify.prototype.pendReady = function (cb) {
+    if (typeof cb !== 'function') {
+        throw new Error('cb must be a function');
+    }
+
+    var self = this;
+    self._pending ++;
+
+    return function pendReadyCb () {
+        cb.apply(this, arguments);
+        if (-- self._pending === 0) self.emit('_ready');
+    };
+};
+// pendReady
+
 function has (obj, key) { return Object.hasOwnProperty.call(obj, key) }
 function isStream (s) { return s && typeof s.pipe === 'function' }
 function isAbsolutePath (file) {

--- a/index.js
+++ b/index.js
@@ -194,13 +194,11 @@ Browserify.prototype.external = function (file, opts) {
     }
     if (file && typeof file === 'object' && typeof file.bundle === 'function') {
         var b = file;
-        self._pending ++;
         b.on('label', function (prev, id) {
             self._external.push(id);
         });
-        b.pipeline.get('label').once('end', function () {
-            if (-- self._pending === 0) self.emit('_ready');
-        });
+        b.pipeline.get('label').once('end', this.pendReady(function () {
+        }));
         return this;
     }
     


### PR DESCRIPTION
This is a proposal to factor out this pattern that's used in several places into a method:

```js
self._pending ++;
somethingAsync(function callback () {
  // ...
  if (-- self._pending === 0) self.emit('_ready');
});
```

So this instead:

```js
somethingAsync(this.pendReady(function callback () {
  // ...
}));
```

The reason I didn't name the method `_pendReady` is because I want to suggest exposing / advertising it to facilitate creating plugins that need to do some kind of async setup. For example, create a plugin that needs to register a transform in a specific position, but needs to do some async setup before the transform can be invoked, e.g.:

```js
function plugin (b, opts) {
  var real_transform;
  
  function placeholder (file) {
    return real_transform(file);
  }
  
  b.transform(placeholder);
  
  something_async(b.pendReady(function () {
    real_transform = ...
  }));
}
```

If you approve I can write some documentation.