### PR TITLE
ensure use of URL path separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -689,7 +689,8 @@ Browserify.prototype._debug = function (opts) {
     return through.obj(function (row, enc, next) {
         if (opts.debug) {
             row.sourceRoot = 'file://localhost';
-            row.sourceFile = path.relative(basedir, row.file);
+            row.sourceFile = path.relative(basedir, row.file)
+                .replace(/\\/g, '/');
         }
         this.push(row);
         next();


### PR DESCRIPTION
On Windows, URLs in sourcemaps are using the `path.sep === '\\'` character rather than the URL `/` character. This breaks folder support in Chrome dev tools, as in:

![image](https://cloud.githubusercontent.com/assets/1106489/5909706/cd095c52-a567-11e4-82d8-8c44ce6ecb2c.png)

This PR ensure that URL separator characters are used instead when Browserify is run on Windows.