### PR TITLE
Support requiring a shimmed module name from an external bundle

### DIFF
--- a/test/external_shim.js
+++ b/test/external_shim.js
@@ -1,0 +1,23 @@
+var browserify = require('../');
+var vm = require('vm');
+var test = require('tap').test;
+
+test('requiring a shimmed module name from an external bundle', function (t) {
+    var b1 = browserify();
+    var b2 = browserify();
+
+    b1.require(__dirname + '/external_shim/bundle1.js', { expose: 'bundle1' });
+    b2.external(b1);
+    b2.require(__dirname + '/external_shim/bundle2.js', { expose: 'bundle2' });
+
+    b1.bundle(function (err, src1) {
+        b2.bundle(function (err, src2) {
+            t.plan(1);
+
+            var c = {setTimeout: setTimeout, console: console};
+            vm.runInNewContext(src1 + src2, c);
+
+            t.ok(c.require('bundle1').shim === c.require('bundle2').shim);
+        });
+    });
+});

--- a/test/external_shim/bundle1.js
+++ b/test/external_shim/bundle1.js
@@ -1,0 +1,1 @@
+exports.shim = require('shim');

--- a/test/external_shim/bundle2.js
+++ b/test/external_shim/bundle2.js
@@ -1,0 +1,1 @@
+exports.shim = require('shim');

--- a/test/external_shim/package.json
+++ b/test/external_shim/package.json
@@ -1,0 +1,5 @@
+{
+    "browser": {
+        "shim": "./shim.js"
+    }
+}


### PR DESCRIPTION
If bundle `A` does  `require('shim')` (which is a reference to ./shim.js in the package.json's `browser` field), and bundle `B` does `external(A)` and tries to also `require('shim')`, then browserify currently throws a `MODULE_NOT_FOUND` error for the second require.

I'd expect that the short name would not only be available to `B`, but that it'd also be smart enough to see that it means the same external module in `A`. A workaround is using `expose` in conjunction with `external` directly on ./shim.js, but that's really unmanageable when you have tons of modules you want shared among multiple sets of bundles for different classes of pages.

I've added a patch and test case which solve this for me, but I don't know if it's robust or correct. If there's another way to achieve this I'd be grateful to hear it. :)