### PR TITLE
Update "browser-pack" and remove unused "umd" dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "through2": "^1.0.0",
     "timers-browserify": "^1.0.1",
     "tty-browserify": "~0.0.0",
-    "umd": "~2.1.0",
     "url": "~0.10.1",
     "util": "~0.10.1",
     "vm-browserify": "~0.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "JSONStream": "~0.8.3",
     "assert": "~1.3.0",
-    "browser-pack": "^3.2.0",
+    "browser-pack": "^4.0.0",
     "browser-resolve": "^1.3.0",
     "browserify-zlib": "~0.1.2",
     "buffer": "^3.0.0",


### PR DESCRIPTION
Update "browser-pack" https://github.com/substack/browser-pack/pull/49.

`umd` is actually used by `browser-pack`, and it has it listed as dependency already.