### PR TITLE
Update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -29,7 +29,7 @@ buffer_ieee754.js has this license in it:
 
 ----
 
-Copyright (c) 2008-2014, Fair Oaks Labs, Inc.
+Copyright (c) 2008-2015, Fair Oaks Labs, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Updated copyright year for 2015. No other files were changed.
![browserify copyright update](https://cloud.githubusercontent.com/assets/8637335/6101024/4bfec024-afd1-11e4-988f-6aa14cc71cbc.png)
