### PR TITLE
Add node v0.12 and iojs on travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_install:
   - npm install -g npm@~1.4.6


### PR DESCRIPTION
I found this pull request https://github.com/substack/node-browserify/pull/1110 . 
Travis CI was failed, but current test works fine in my environment. 
I would like to test this again.