### PR TITLE
Document opts.paths in api

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -375,6 +375,11 @@ By default browserify considers only `.js` and `.json` files in such cases.
 `opts.basedir` is the directory that browserify starts bundling from for
 filenames that start with `.`.
 
+`opts.paths` is an array of directories that browserify searches when looking
+for modules which are not referenced using relative path. Can be absolute or
+relative to `basedir`. Equivalent of setting `NODE_PATH` environmental variable
+when calling `browserify` command.
+
 `opts.commondir` sets the algorithm used to parse out the common paths. Use
 `false` to turn this off, otherwise it uses the
 [commondir](https://npmjs.org/package/commondir) module.


### PR DESCRIPTION
There are several bundles in a project I am working on, each created with different `NODE_PATH` variable when calling `browserify`. 

I wanted to generate the bundles from single node process using browserify api (repective watchify, but that is irrelevant to this PR), and without knowing about `paths` option that was impossible.

I noticed that in #767 it is mentioned that `paths` option is deprecated because `NODE_PATH` is deprecated. From looking at node documentation, it does not seem to me that `NODE_PATH` is deprecated, and I believe it is handy to have an api options with equivalent functionality.

If it is deprecated, we could still document it, but mark it as deprecated with explanation why.