### PR TITLE
Grab expose field specified after last colon, handling Windows

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -134,7 +134,7 @@ module.exports = function (args, opts) {
 
     [].concat(argv.require).filter(Boolean)
         .forEach(function (r) {
-            var xs = r.split(':');
+            var xs = _splitOnColon(r);
             b.require(xs[0], { expose: xs.length === 1 ? xs[0] : xs[1] })
         })
     ;
@@ -142,8 +142,8 @@ module.exports = function (args, opts) {
     // resolve any external files and add them to the bundle as externals
     [].concat(argv.external).filter(Boolean)
         .forEach(function (x) {
-            if (/:/.test(x)) {
-                var xs = x.split(':');
+            var xs = _splitOnColon(x);
+            if (xs.length === 2) {
                 add(xs[0], { expose: xs[1] });
             }
             else if (/\*/.test(x)) {
@@ -241,4 +241,17 @@ function copy (obj) {
         acc[key] = obj[key];
         return acc;
     }, {});
+}
+
+function _splitOnColon (f) {
+    var pos = f.lastIndexOf(':');
+    if (pos == -1) {
+        return [f]; // No colon
+    } else {
+        if ((/[a-zA-Z]:[\\/]/.test(f)) && (pos == 1)){
+            return [f]; // Windows path and colon is part of drive name
+        } else {
+            return [f.substr(0, pos), f.substr(pos + 1)];
+        }
+    }
 }

--- a/test/args.js
+++ b/test/args.js
@@ -52,3 +52,19 @@ test('numeric module names', function(t) {
         t.notOk(err);
     });
 });
+
+test('entry expose', function (t) {
+    t.plan(3)
+    
+    var b = fromArgs([
+        path.join(__dirname, '/entry_expose/main.js'),
+        '--require', path.join(__dirname, '/entry_expose/main.js') + ':x',
+    ]);
+    b.bundle(function (err, src) {
+        t.ifError(err);
+        var c = { console: { log: log } };
+        function log (msg) { t.equal(msg, 'wow') }
+        vm.runInNewContext(src, c);
+        t.equal(c.require('x'), 555);
+    })
+});


### PR DESCRIPTION
Take care of the colon used as drive specifier under Windows.
Add corresponding test case to test/args.js