### PR TITLE
More OS-agnostic tests, less dust in temporary folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,10 +76,9 @@
     "coffee-script": "~1.5.0",
     "coffeeify": "~0.6.0",
     "es6ify": "~0.4.8",
-    "mkdirp": "~0.3.3",
-    "osenv": "^0.1.0",
     "seq": "0.3.3",
     "tap": "~0.4.0",
+    "temp": "^0.8.1",
     "through": "^2.3.4"
   },
   "author": {

--- a/test/args.js
+++ b/test/args.js
@@ -26,7 +26,7 @@ test('external flag for node modules', function(t) {
 });
 
 test('bundle from an arguments with --insert-global-vars', function (t) {
-    t.plan(3)
+    t.plan(4);
 
     var b = fromArgs([
         __dirname + '/global/filename.js',
@@ -35,12 +35,14 @@ test('bundle from an arguments with --insert-global-vars', function (t) {
     ]);
     b.require(__dirname + '/global/filename.js', { expose: 'x' });
     b.bundle(function (err, src) {
-        t.ifError(err);
-        var c = {};
+        t.ifError(err, 'b.bundle()');
+        var c = {}, x;
         vm.runInNewContext(src, c);
-        var x = c.require('x');
-        t.equal(x.filename, '/global/filename.js');
-        t.equal(x.dirname, '/global');
+        t.doesNotThrow(function() {
+            x = c.require('x');
+        }, 'x = c.require(\'x\')');
+        t.equal(x && x.filename, '/global/filename.js', 'x.filename');
+        t.equal(x && x.dirname, '/global', 'x.dirname');
     })
 });
 
@@ -49,6 +51,6 @@ test('numeric module names', function(t) {
 
     var b = fromArgs([ '-x', '1337' ]);
     b.bundle(function (err, src) {
-        t.notOk(err);
+        t.ifError(err);
     });
 });

--- a/test/coffee_bin.js
+++ b/test/coffee_bin.js
@@ -11,7 +11,7 @@ test('compiling coffee with -c', function (t) {
     
     var ps = spawn(process.execPath, [
         path.resolve(__dirname, '../bin/cmd.js'),
-        '-c', __dirname + '/../node_modules/.bin/coffee -sc',
+        '-c', '"' + process.execPath + '" "' + __dirname + '/../node_modules/coffee-script/bin/coffee" -sc',
         'coffee_bin/main.coffee'
     ]);
     var src = '';

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -5,9 +5,9 @@ var fs = require('fs');
 var vm = require('vm');
 var concat = require('concat-stream');
 
-var mkdirp = require('mkdirp');
-var tmpdir = '/tmp/browserify-test/' + Math.random().toString(16).slice(2);
-mkdirp.sync(tmpdir);
+var temp = require('temp');
+temp.track();
+var tmpdir = temp.mkdirSync({prefix: 'browserify-test'});
 
 fs.writeFileSync(tmpdir + '/main.js', 'beep(require("crypto"))\n');
 

--- a/test/crypto_ig.js
+++ b/test/crypto_ig.js
@@ -5,9 +5,9 @@ var fs = require('fs');
 var vm = require('vm');
 var concat = require('concat-stream');
 
-var mkdirp = require('mkdirp');
-var tmpdir = '/tmp/browserify-test/' + Math.random().toString(16).slice(2);
-mkdirp.sync(tmpdir);
+var temp = require('temp');
+temp.track();
+var tmpdir = temp.mkdirSync({prefix: 'browserify-test'});
 
 fs.writeFileSync(tmpdir + '/main.js', 'beep(require("crypto"))\n');
 
@@ -15,7 +15,7 @@ test('crypto --insertGlobals', function (t) {
     t.plan(2);
     
     var bin = __dirname + '/../bin/cmd.js';
-    var ps = spawn(bin, [ 'main.js', '--ig' ], { cwd : tmpdir });
+    var ps = spawn(process.execPath, [ bin, 'main.js', '--ig' ], { cwd : tmpdir });
     
     ps.stderr.pipe(process.stderr, { end : false });
     

--- a/test/externalize.js
+++ b/test/externalize.js
@@ -2,17 +2,15 @@ var test = require('tap').test;
 var spawn = require('child_process').spawn;
 var concat = require('concat-stream');
 var path = require('path');
-var mkdirp = require('mkdirp');
 var fs = require('fs');
 var vm = require('vm');
 
-var tmpdir = path.join(
-    require('osenv').tmpdir(),
-    'browserify-test-' + Math.random()
-);
+var temp = require('temp');
+temp.track();
+var tmpdir = temp.mkdirSync({prefix: 'browserify-test'});
 var pubdir = path.join(tmpdir, 'public');
 
-mkdirp.sync(pubdir);
+fs.mkdirSync(pubdir);
 fs.writeFileSync(
     path.join(tmpdir, 'robot.js'),
     fs.readFileSync(path.join(__dirname, 'externalize/robot.js'))

--- a/test/file_event.js
+++ b/test/file_event.js
@@ -15,7 +15,7 @@ test('file event', function (t) {
     
     b.on('file', function (file, id) {
         var key = path.basename(file);
-        t.equal(file, __dirname + '/entry/' + key);
+        t.equal(file, path.join(__dirname, 'entry', key));
         t.equal(id, files[key]);
         delete files[key];
     });

--- a/test/full_paths.js
+++ b/test/full_paths.js
@@ -2,11 +2,12 @@ var unpack = require('browser-unpack');
 var browserify = require('../');
 var test = require('tap').test;
 var vm = require('vm');
+var path = require('path');
 
 var deps = [
-    __dirname + '/entry/main.js',
-    __dirname + '/entry/one.js',
-    __dirname + '/entry/two.js'
+    path.join(__dirname, '/entry/main.js'),
+    path.join(__dirname, '/entry/one.js'),
+    path.join(__dirname, '/entry/two.js')
 ];
 
 test('fullPaths enabled', function (t) {

--- a/test/pkg.js
+++ b/test/pkg.js
@@ -1,9 +1,10 @@
 var browserify = require('../');
 var vm = require('vm');
 var test = require('tap').test;
+var path = require('path');
 
 var pkg = require('./pkg/package.json');
-pkg.__dirname = __dirname + '/pkg';
+pkg.__dirname = path.join(__dirname, 'pkg');
 
 test('package', function (t) {
     t.plan(2);

--- a/test/stream_file.js
+++ b/test/stream_file.js
@@ -3,17 +3,18 @@ var vm = require('vm');
 var test = require('tap').test;
 var fs = require('fs');
 var through = require('through2');
+var path = require('path');
 
 test('stream file', function (t) {
     var expected = {};
-    expected[__dirname + '/stream/fake.js'] = true;
-    expected[__dirname + '/stream/bar.js'] = true;
-    expected[__dirname + '/stream/foo.js'] = true;
+    expected[ path.join(__dirname, 'stream/fake.js') ] = true;
+    expected[ path.join(__dirname, 'stream/bar.js' ) ] = true;
+    expected[ path.join(__dirname, 'stream/foo.js' ) ] = true;
     
     t.plan(5);
     
     var stream = fs.createReadStream(__dirname + '/stream/main.js');
-    stream.file = __dirname + '/stream/fake.js';
+    stream.file = path.join(__dirname, '/stream/fake.js');
     
     var b = browserify(stream, { basedir: __dirname + '/stream' });
     b.transform(function (file) {

--- a/test/tr_once.js
+++ b/test/tr_once.js
@@ -2,13 +2,14 @@ var browserify = require('../');
 var vm = require('vm');
 var test = require('tap').test;
 var through = require('through2');
+var path = require('path');
 
 test('transform exactly once', function (t) {
     t.plan(3);
     
     var b = browserify(__dirname + '/tr_once/main.js', {
         transform: function (file) {
-        t.equal(file, __dirname + '/tr_once/main.js');
+        t.equal(file, path.join(__dirname, 'tr_once/main.js') );
             return through();
         }
     });


### PR DESCRIPTION
Use path.join() to get local styled filepath.
Use Temp package to create temporary folders on OS specific place,
plus wiping stuff after tests.
Provide node-executable location to spawn().