### PR TITLE
Fix #1194

### DIFF
--- a/index.js
+++ b/index.js
@@ -732,7 +732,6 @@ Browserify.prototype.reset = function (opts) {
 
 Browserify.prototype.bundle = function (cb) {
     var self = this;
-    var output = readonly(this.pipeline);
     if (cb && typeof cb === 'object') {
         throw new Error(
             'bundle() no longer accepts option arguments.\n'
@@ -746,6 +745,7 @@ Browserify.prototype.bundle = function (cb) {
             self.pipeline.write(x);
         });
     }
+    var output = readonly(this.pipeline);
     if (cb) {
         output.on('error', cb);
         this.pipeline.pipe(concat(function (body) {


### PR DESCRIPTION
since 9.0.6, `bundle()` returns a read-only stream by `var output = readonly(this.pipeline)`

but if `this._bundled` is true, a 'reset' will be triggered, which cause the
problem mentioned in #1194, because `this.pipeline !== output` after `this.reset()`, they are not the same thing anymore.