### PR TITLE
Fix expose field for external modules and builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,14 +143,17 @@ Browserify.prototype.require = function (file, opts) {
         }));
         return this;
     }
-    
-    var row = typeof file === 'object'
-        ? xtend(file, opts)
-        : (isExternalModule(file)
-            ? xtend(opts, { id: expose || file })
-            : xtend(opts, { file: file })
-        )
-    ;
+
+    var row;
+    if (typeof file === 'object') {
+        row = xtend(file, opts);
+    } else if (isExternalModule(file)) {
+        // external module or builtin
+        row = xtend(opts, { id: expose || file, file: file });
+    } else {
+        row = xtend(opts, { file: file });
+    };
+
     if (!row.id) {
         row.id = expose || file;
     }

--- a/test/require_expose.js
+++ b/test/require_expose.js
@@ -2,6 +2,32 @@ var browserify = require('../');
 var test = require('tap').test;
 var vm = require('vm');
 
+test('require expose external module', function (t) {
+    t.plan(2);
+    
+    var b = browserify({ basedir: __dirname });
+    b.require('beep', { expose: 'bip' });
+    b.bundle(function (err, src) {
+        t.ifError(err);
+        var c = { };
+        vm.runInNewContext(src, c);
+        t.equal(c.require('bip'), 'boop');
+    })
+});
+
+test('renaming builtin', function (t) {
+    t.plan(2);
+    
+    var b = browserify({ basedir: __dirname });
+    b.require('os', { expose: 'bone' });
+    b.bundle(function (err, src) {
+        t.ifError(err);
+        var c = { };
+        vm.runInNewContext(src, c);
+        t.equal(c.require('bone').platform(), 'browser');
+    })
+});
+
 test('exposed modules do not leak across bundles', function (t) {
     var bundle1, bundle2;
 


### PR DESCRIPTION
Added the 'file' field at row creation in require() for external modules and builtins.
Added two tests cases.
Unnested ternary operators (style only).
Fix current https://github.com/substack/node-browserify/issues/850
Feedback very welcome !