### PR TITLE
Accept glob string for [entry files] ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var inherits = require('inherits');
 var EventEmitter = require('events').EventEmitter;
 var xtend = require('xtend');
 var copy = require('shallow-copy');
+var glob = require('glob');
 var isarray = require('isarray');
 var defined = require('defined');
 var has = require('has');
@@ -39,6 +40,11 @@ function Browserify (files, opts) {
         opts = xtend(opts, { entries: [].concat(opts.entries || [], files) });
     }
     else opts = xtend(files, opts);
+    
+    if (isarray(opts.entries) && opts.entries.length === 1 
+      && typeof opts.entries[0] === 'string' && glob.hasMagic(opts.entries[0])) {
+       opts.entries = glob.sync(opts.entries[0]);
+    }
     
     self._options = opts;
     if (opts.noparse) opts.noParse = opts.noparse;


### PR DESCRIPTION
...in command "browserify [entry files] {OPTIONS}"
Windows does not auto expand globs on the command line

Creating the pull request to try and progress. It works locally for me, but an automated test case would be awesome. I can't tell how to make such a test case examining the existing suite.

This pull request is for https://github.com/substack/node-browserify/issues/1170