### PR TITLE
Remove 'v' shortcut for version

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -20,7 +20,7 @@ if (b.argv._[0] === 'help' || b.argv.h || b.argv.help
         .on('close', function () { process.exit(1) })
     ;
 }
-if (b.argv.v || b.argv.version) {
+if (b.argv.version) {
     return console.log(require('../package.json').version);
 }
 


### PR DESCRIPTION
This is part of an effort to bring consistency to the browserify and watchify flags (as somewhat discussed in https://github.com/substack/watchify/pull/204#issuecomment-93759292).

watchify already uses "v" for "verbose", and has no "version" flag. By removing the (arguably) seldom used "v" from browserify, (1) watchify can fully "own" it, and (2) can add a "version" flag without clashing with browserify's short form of it. Also, a lot of unix tools don't have a "v", just "version".

Alternatively, "v" could be replaced with "V" - [ssh](http://linux.die.net/man/1/ssh), [less](http://linux.die.net/man/1/less), among other do this.

cc: @jmm 