### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "insert-module-globals": "^6.2.0",
     "isarray": "0.0.1",
     "labeled-stream-splicer": "^1.0.0",
-    "module-deps": "^3.7.0",
+    "module-deps": "^3.7.7",
     "os-browserify": "~0.1.1",
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "constants-browserify": "~0.0.1",
     "crypto-browserify": "^3.0.0",
     "deep-equal": "^1.0.0",
-    "defined": "~0.0.0",
+    "defined": "^1.0.0",
     "deps-sort": "^1.3.5",
     "domain-browser": "~1.1.0",
     "duplexer2": "~0.0.2",
@@ -51,7 +51,7 @@
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",
     "process": "^0.10.0",
-    "punycode": "~1.2.3",
+    "punycode": "^1.3.2",
     "querystring-es3": "~0.2.0",
     "read-only-stream": "^1.1.1",
     "readable-stream": "^1.1.13",
@@ -69,7 +69,7 @@
     "url": "~0.10.1",
     "util": "~0.10.1",
     "vm-browserify": "~0.0.1",
-    "xtend": "^3.0.0"
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "backbone": "~0.9.2",


### PR DESCRIPTION
* The update of defined and xtend are so we can get npm to dedupe them. It's already in https://github.com/substack/insert-module-globals/pull/42, https://github.com/substack/deps-sort/pull/4, https://github.com/substack/module-deps/pull/82 and https://github.com/substack/browser-pack/pull/56.

* I'm also updating and pinning punycode to 1.3.2 for deduping purposes. But I chose to not make it floating since [url](https://github.com/defunctzombie/node-url/blob/v0.10.3/package.json#L6) also has it pinned there.

* And I'm updating module-deps, despite that the `^` already covers the version, so that over in watchify I can count on https://github.com/substack/module-deps/pull/80 always being in whatever is the next browserify version we publish.

The motivation for the deduping is https://github.com/substack/node-browserify/issues/707#issuecomment-96273418.

---

@jmm and @terinjokes: This should be published as 9.0.9. But since https://github.com/substack/node-browserify/pull/1222 hasn't been published, strict semver dictates that we move to 10.0.0. I think that's over kill for removing the "v" flag. I'll hold off publishing until you chime in.