### PR TITLE
Update process to ~0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "os-browserify": "~0.1.1",
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",
-    "process": "^0.10.0",
+    "process": "~0.11.0",
     "punycode": "^1.3.2",
     "querystring-es3": "~0.2.0",
     "read-only-stream": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "http-browserify": "^1.4.0",
     "https-browserify": "~0.0.0",
     "inherits": "~2.0.1",
-    "insert-module-globals": "^6.2.0",
+    "insert-module-globals": "^6.4.0",
     "isarray": "0.0.1",
     "labeled-stream-splicer": "^1.0.0",
     "module-deps": "^3.7.7",

--- a/test/bundle.js
+++ b/test/bundle.js
@@ -13,6 +13,7 @@ test('bundle', function (t) {
         
         var c = {
             setTimeout : setTimeout,
+            clearTimeout : clearTimeout,
             console : console
         };
         vm.runInNewContext(src, c);

--- a/test/coffeeify.js
+++ b/test/coffeeify.js
@@ -11,7 +11,8 @@ test('coffeeify with an implicit global', function (t) {
         if (err) t.fail(err);
         vm.runInNewContext(src, {
             console: { log: log },
-            setTimeout: setTimeout
+            setTimeout: setTimeout,
+            clearTimeout: clearTimeout
         });
         function log (msg) { t.equal(msg, 'eyo') }
     });

--- a/test/external_shim.js
+++ b/test/external_shim.js
@@ -14,7 +14,11 @@ test('requiring a shimmed module name from an external bundle', function (t) {
         b2.bundle(function (err, src2) {
             t.plan(1);
 
-            var c = {setTimeout: setTimeout, console: console};
+            var c = {
+                console: console,
+                setTimeout: setTimeout,
+                clearTimeout: clearTimeout
+            };
             vm.runInNewContext(src1 + src2, c);
 
             t.ok(c.require('bundle1').shim === c.require('bundle2').shim);

--- a/test/global.js
+++ b/test/global.js
@@ -69,7 +69,7 @@ test('process.nextTick', function (t) {
     var b = browserify();
     b.add(__dirname + '/global/tick.js');
     b.bundle(function (err, src) {
-        var c = { t: t, setTimeout: setTimeout };
+        var c = { t: t, setTimeout: setTimeout, clearTimeout: clearTimeout };
         vm.runInNewContext(src, c);
     });
 });

--- a/test/global_coffeeify.js
+++ b/test/global_coffeeify.js
@@ -11,7 +11,8 @@ test('coffeeify globally', function (t) {
         if (err) t.fail(err);
         vm.runInNewContext(src, {
             console: { log: log },
-            setTimeout: setTimeout
+            setTimeout: setTimeout,
+            clearTimeout: clearTimeout
         });
         function log (msg) { t.equal(msg, 'eyo') }
     });

--- a/test/leak.js
+++ b/test/leak.js
@@ -30,7 +30,11 @@ test('leaking information about system paths (process)', function (t) {
         t.equal(src.indexOf(dirstring), -1, 'temp directory visible');
         t.equal(src.indexOf(process.cwd()), -1, 'cwd directory visible');
         t.equal(src.indexOf('/home'), -1, 'home directory visible');
-        vm.runInNewContext(src, { t: t, setTimeout: setTimeout });
+        vm.runInNewContext(src, {
+            t: t,
+            setTimeout: setTimeout,
+            clearTimeout: clearTimeout
+        });
     });
 });
 

--- a/test/process.js
+++ b/test/process.js
@@ -13,7 +13,8 @@ test('implicit process global', function (t) {
                 t.equal(two, 2);
                 t.end();
             },
-            setTimeout: setTimeout
+            setTimeout: setTimeout,
+            clearTimeout: clearTimeout
         };
         vm.runInNewContext(src, c);
     });

--- a/test/reset.js
+++ b/test/reset.js
@@ -18,6 +18,7 @@ test('reset', function (t) {
         t.ifError(err);
         var c = {
             setTimeout : setTimeout,
+            clearTimeout : clearTimeout,
             console : console
         };
         vm.runInNewContext(src, c);

--- a/test/reverse_multi_bundle.js
+++ b/test/reverse_multi_bundle.js
@@ -38,6 +38,7 @@ test('reverse multi bundle', function (t) {
             var src = appSrc + ';' + lazySrc;
             var c = {
                 setTimeout: setTimeout,
+                clearTimeout: clearTimeout,
                 t: t
             };
             vm.runInNewContext(src, c);


### PR DESCRIPTION
Fixes https://github.com/substack/node-browserify/issues/1179. This also solves my major-version-bump dilemma from https://github.com/substack/node-browserify/pull/1230 because this merits it for sure.

The reason for having to pass in `clearTimeout` into the context in tests is because there is now a queue in `process.nextTick` that depends on it (see https://github.com/defunctzombie/node-process/pull/38 and https://github.com/defunctzombie/node-process/compare/v0.10.1...v0.11.0.).

cc: @jmm @terinjokes 