### PR TITLE
--no-browser-field and --node

### DIFF
--- a/bin/advanced.txt
+++ b/bin/advanced.txt
@@ -51,6 +51,15 @@ Advanced Options:
     to just "__filename,__dirname". This is handy if you want to run bundles in
     node.
 
+  --no-browser-field, --no-bf
+
+    Turn off package.json browser field resolution. This is also handy if you
+    need to run a bundle in node.
+
+  --node
+
+    Alias for --bare and --no-browser-field.
+
   --full-paths
 
     Turn off converting module ids into numerical indexes. This is useful for
@@ -70,7 +79,7 @@ Advanced Options:
     Consider files with specified EXTENSION as modules, this option can used
     multiple times.
 
-  --global-transform=MODULE, --g MODULE
+  --global-transform=MODULE, -g MODULE
 
     Use a transform module on all files after any ordinary transforms have run.
 

--- a/bin/args.js
+++ b/bin/args.js
@@ -13,12 +13,14 @@ module.exports = function (args, opts) {
     var argv = subarg(args, {
         'boolean': [
             'deps', 'pack', 'ig', 'dg', 'im', 'd', 'list', 'builtins',
-            'commondir', 'bare', 'full-paths', 'bundle-external'
+            'commondir', 'bare', 'full-paths', 'bundle-external', 'bf',
+            'node'
         ],
         string: [ 's', 'r', 'u', 'x', 't', 'i', 'o', 'e', 'c', 'it' ],
         alias: {
             ig: [ 'insert-globals', 'fast' ],
             dg: [ 'detect-globals', 'detectGlobals', 'dg' ],
+            bf: [ 'browser-field', 'browserField ' ],
             im: 'ignore-missing',
             it: 'ignore-transform',
             igv: 'insert-global-vars',
@@ -43,7 +45,9 @@ module.exports = function (args, opts) {
             d: false,
             builtins: true,
             commondir: true,
-            'bundle-external': true
+            'bundle-external': true,
+            bf: true,
+            node: false
         }
     });
     
@@ -60,6 +64,10 @@ module.exports = function (args, opts) {
         return path.resolve(process.cwd(), entry);
     });
     
+    if (argv.node) {
+        argv.bare = true;
+        argv.browserField = false;
+    }
     if (argv.bare) {
         argv.builtins = false;
         argv.commondir = false;
@@ -80,6 +88,7 @@ module.exports = function (args, opts) {
         commondir: argv.commondir === false ? false : undefined,
         bundleExternal: argv['bundle-external'],
         basedir: argv.basedir,
+        browserField: argv.browserField,
         
         detectGlobals: argv.detectGlobals,
         insertGlobals: argv['insert-globals'] || argv.ig,

--- a/index.js
+++ b/index.js
@@ -61,6 +61,13 @@ function Browserify (files, opts) {
     self._transforms = [];
     self._entryOrder = 0;
     self._ticked = false;
+    self._bresolve = opts.browserField === false
+        ? function (id, opts, cb) {
+            if (!opts.basedir) opts.basedir = path.dirname(opts.filename)
+            resolve(id, opts, cb)
+        }
+        : bresolve
+    ;
 
     var ignoreTransform = [].concat(opts.ignoreTransform).filter(Boolean);
     self._filterTransform = function (tr) {
@@ -447,7 +454,7 @@ Browserify.prototype._createDeps = function (opts) {
     mopts.resolve = function (id, parent, cb) {
         if (self._ignore.indexOf(id) >= 0) return cb(null, paths.empty, {});
         
-        bresolve(id, parent, function (err, file, pkg) {
+        self._bresolve(id, parent, function (err, file, pkg) {
             if (file && self._ignore.indexOf(file) >= 0) {
                 return cb(null, paths.empty, {});
             }

--- a/readme.markdown
+++ b/readme.markdown
@@ -159,6 +159,15 @@ Advanced Options:
     to just "__filename,__dirname". This is handy if you want to run bundles in
     node.
 
+  --no-browser-field, --no-bf
+
+    Turn off package.json browser field resolution. This is also handy if you
+    need to run a bundle in node.
+
+  --node
+
+    Alias for --bare and --no-browser-field.
+
   --full-paths
 
     Turn off converting module ids into numerical indexes. This is useful for
@@ -177,11 +186,6 @@ Advanced Options:
 
     Consider files with specified EXTENSION as modules, this option can used
     multiple times.
-
-  --ignore-transform=MODULE, --it MODULE
-
-    Any transforms matching the given name will be ignored, including
-    those in your module dependencies. 
 
   --global-transform=MODULE, -g MODULE
 

--- a/test/ignore_browser_field.js
+++ b/test/ignore_browser_field.js
@@ -1,0 +1,21 @@
+var test = require('tap').test;
+var browserify = require('../');
+var path = require('path');
+var mainfile = path.join(__dirname, 'ignore_browser_field/main.js');
+var vm = require('vm');
+
+test('ignore browser field', function (t) {
+    t.plan(3);
+    var b = browserify(mainfile, { browserField: false });
+    var expected = [ 'A:NODE', 'B:X.JS' ];
+    
+    b.bundle(function (err, src) {
+        t.ifError(err);
+        var c = { console: { log: log } };
+        vm.runInNewContext(src, c);
+        
+        function log (msg) {
+            t.equal(msg, expected.shift());
+        }
+    });
+});

--- a/test/ignore_browser_field/main.js
+++ b/test/ignore_browser_field/main.js
@@ -1,0 +1,2 @@
+console.log(require('a'));
+console.log(require('b'));

--- a/test/ignore_browser_field/node_modules/a/browser.js
+++ b/test/ignore_browser_field/node_modules/a/browser.js
@@ -1,0 +1,1 @@
+module.exports = 'A:BROWSER'

--- a/test/ignore_browser_field/node_modules/a/main.js
+++ b/test/ignore_browser_field/node_modules/a/main.js
@@ -1,0 +1,1 @@
+module.exports = 'A:NODE'

--- a/test/ignore_browser_field/node_modules/a/package.json
+++ b/test/ignore_browser_field/node_modules/a/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "main": "main.js",
+  "browser": "browser.js"
+}

--- a/test/ignore_browser_field/node_modules/b/browser-x.js
+++ b/test/ignore_browser_field/node_modules/b/browser-x.js
@@ -1,0 +1,1 @@
+module.exports = 'browser-x.js'

--- a/test/ignore_browser_field/node_modules/b/main.js
+++ b/test/ignore_browser_field/node_modules/b/main.js
@@ -1,0 +1,1 @@
+module.exports = ('b:' + require('./x.js')).toUpperCase();

--- a/test/ignore_browser_field/node_modules/b/package.json
+++ b/test/ignore_browser_field/node_modules/b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "main": "main.js",
+  "browser": {
+    "./x.js": "./browser-x.js"
+  }
+}

--- a/test/ignore_browser_field/node_modules/b/x.js
+++ b/test/ignore_browser_field/node_modules/b/x.js
@@ -1,0 +1,1 @@
+module.exports = 'x.js';


### PR DESCRIPTION
This patch adds support for `--no-browser-field` to turn off the package.json browser field machinery. This is useful if you are targeting a node environment with the bundle, such as [code coverage](https://npmjs.com/package/coverify), to apply transforms to server code, or to target other platforms like chrome apps.

This feature is also available as `opts.browserField = false`. `--node` is added as an alias for `--bare` and `--no-browser-field`.