### PR TITLE
Bump module-deps to ^3.7.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "insert-module-globals": "^6.4.0",
     "isarray": "0.0.1",
     "labeled-stream-splicer": "^1.0.0",
-    "module-deps": "^3.7.7",
+    "module-deps": "^3.7.10",
     "os-browserify": "~0.1.1",
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",


### PR DESCRIPTION
```
# 10.1.1

* Updates module-deps to ^3.7.10, which fixes an issue where under certain conditions the directory for a `package.json` would be attributed to the wrong package. [substack/module-deps#81](https://github.com/substack/module-deps/pull/81) (thanks @pmowrer)
```