### PR TITLE
Replace JSONStream with jsonstream

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 var fs = require('fs');
-var JSONStream = require('JSONStream');
+var JSONStream = require('jsonstream');
 var through = require('through2');
 
 var b = require('./args')(process.argv.slice(2));

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "javascript"
   ],
   "dependencies": {
-    "JSONStream": "~0.10.0",
     "assert": "~1.3.0",
     "browser-pack": "^4.0.0",
     "browser-resolve": "^1.7.1",
@@ -46,6 +45,7 @@
     "inherits": "~2.0.1",
     "insert-module-globals": "^6.4.0",
     "isarray": "0.0.1",
+    "jsonstream": "^1.0.3",
     "labeled-stream-splicer": "^1.0.0",
     "module-deps": "^3.7.7",
     "os-browserify": "~0.1.1",


### PR DESCRIPTION
NPM now has opinions about names of modules when publishing. We have an internal NPM registry and cannot sync browserify to is due to this dependency. No fear, @dominictarr has published a lowercase version.

- [x] browser-pack https://github.com/substack/browser-pack/pull/57
- [x] deps-sort https://github.com/substack/deps-sort/pull/5
- [x] insert-module-globals https://github.com/substack/insert-module-globals/pull/44
- [x] module-deps https://github.com/substack/module-deps/pull/84