### PR TITLE
Make sure entry paths are always full paths

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -61,7 +61,7 @@ module.exports = function (args, opts) {
             s.resume();
             return rs;
         }
-        return path.resolve(process.cwd(), entry);
+        return entry;
     });
     
     if (argv.node) {

--- a/index.js
+++ b/index.js
@@ -180,7 +180,11 @@ Browserify.prototype.require = function (file, opts) {
         self._bpack.hasExports = true;
     }
     
-    if (row.entry) row.order = self._entryOrder ++;
+    if (row.entry) {
+        row.file = path.resolve(basedir, row.file);
+        row.order = self._entryOrder ++;
+    }
+    
     if (opts.transform === false) row.transform = false;
     self.pipeline.write(row);
     return self;

--- a/test/entry_relative.js
+++ b/test/entry_relative.js
@@ -2,10 +2,10 @@ var browserify = require('../');
 var vm = require('vm');
 var test = require('tap').test;
 
-test('entry', function (t) {
+test('entry - relative path', function (t) {
     t.plan(3);
-    
-    var b = browserify(__dirname + '/entry/main.js');
+
+    var b = browserify('entry/main.js');
     b.on('dep', function(row) {
         if (row.entry) t.equal(row.file, __dirname + '/entry/main.js');
     });
@@ -21,11 +21,11 @@ test('entry', function (t) {
     });
 });
 
-test('entry via add', function (t) {
+test('entry - relative path via add', function (t) {
     t.plan(3);
     
-    var b = browserify();
-    b.add(__dirname + '/entry/main.js');
+    var b = browserify({basedir: __dirname});
+    b.add('entry/main.js');
     b.on('dep', function(row) {
         if (row.entry) t.equal(row.file, __dirname + '/entry/main.js');
     });

--- a/test/multi_entry.js
+++ b/test/multi_entry.js
@@ -10,14 +10,20 @@ var testFiles = [
 ];
 
 test('multi entry', function (t) {
-    t.plan(3);
+    t.plan(6);
     
     var b = browserify([
         testFiles[0],
         testFiles[1]
     ]);
     b.add(testFiles[2]);
-
+    
+    b.on('dep', function(row) {
+        if (row.entry) {
+            t.ok(testFiles.indexOf(row.file) > -1, 'should contain full entry path');
+        }
+    });
+    
     b.bundle(function (err, src) {
         var c = {
             times : 0,
@@ -28,7 +34,7 @@ test('multi entry', function (t) {
 });
 
 test('entries as streams', function (t) {
-    t.plan(3);
+    t.plan(6);
     
     // transform paths to streams
     for (var i = 0; i < testFiles.length; i++) {
@@ -43,6 +49,16 @@ test('entries as streams', function (t) {
         testFiles[1]
     ], opts);
     b.add(testFiles[2]);
+    
+    b.on('dep', function(row) {
+        if (row.entry) {
+            t.similar(
+                row.file,
+                RegExp(__dirname + '/multi_entry/_stream_[\\d].js'),
+                'should be full entry path'
+            );
+        }
+    });
     
     b.bundle(function (err, src) {
         var c = {


### PR DESCRIPTION
When using the CLI, entry files were always resolved to absolute paths, but when using the API, they weren't. module-deps respects the `row.file` on its initial rows insofar that it resolved relative paths (based on `opts.basedir`) but it didn't rewrite it on the `row`. This led to a weird behavior with watchify where entry files were never being pulled from the cache - unless you used the CLI or passed in an absolute path via the API.

Using `basedir` to resolve the path is consistent with @substack's view on path resolution ("require vs entry" in https://github.com/substack/node-browserify/issues/1219#issuecomment-96126563).

This PR also adds a few tests that use the relative path behavior and extends others to verify that `row.file` is always the absolute path. 

cc: @jmm @terinjokes