### PR TITLE
Update to browser-pack@^5.0.0 and fix source-map test

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "JSONStream": "^1.0.3",
     "assert": "~1.3.0",
-    "browser-pack": "^4.0.3",
+    "browser-pack": "^5.0.0",
     "browser-resolve": "^1.7.1",
     "browserify-zlib": "~0.1.2",
     "buffer": "^3.0.0",

--- a/test/debug_standalone.js
+++ b/test/debug_standalone.js
@@ -16,7 +16,7 @@ test('ordinary debug', function (t) {
         var src = buf.toString('utf8');
         var last = src.split('\n').slice(-2)[0];
         t.ok(
-            /\/\/# sourceMappingURL=data:application\/json;base64,[\w+\/=]+$/
+            /\/\/# sourceMappingURL=data:application\/json;charset:utf-8;base64,[\w+\/=]+$/
             .test(last)
         );
     });
@@ -35,7 +35,7 @@ test('debug standalone', function (t) {
         var src = buf.toString('utf8');
         var last = src.split('\n').slice(-2)[0];
         t.ok(
-            /\/\/# sourceMappingURL=data:application\/json;base64,[\w+\/=]+$/
+            /\/\/# sourceMappingURL=data:application\/json;charset:utf-8;base64,[\w+\/=]+$/
             .test(last)
         );
     });
@@ -54,7 +54,7 @@ test('debug standalone exposed', function (t) {
         var src = buf.toString('utf8');
         var last = src.split('\n').slice(-2)[0];
         t.ok(
-            /\/\/# sourceMappingURL=data:application\/json;base64,[\w+\/=]+$/
+            /\/\/# sourceMappingURL=data:application\/json;charset:utf-8;base64,[\w+\/=]+$/
             .test(last)
         );
         var c = { window: {} };


### PR DESCRIPTION
https://github.com/substack/browser-pack/pull/60 in browser-pack has an updated source maps module that now includes the charset - so our tests need to be updated. <del>I plan on publishing it a browser-pack@5.0.0 tomorrow.</del> Done!. We should take this opportunity to merge some of the other stuff in here and make the jump to v11.0.0. @jmm @terinjokes 