### PR TITLE
Fix multi-entry with cross-require

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,16 +156,16 @@ Browserify.prototype.require = function (file, opts) {
     if (typeof file === 'object') {
         row = xtend(file, opts);
     }
-    else if (isExternalModule(file)) {
+    else if (!opts.entry && isExternalModule(file)) {
         // external module or builtin
         row = xtend(opts, { id: expose || file, file: file });
     }
     else {
-        row = xtend(opts, { file: file });
+        row = xtend(opts, { file: path.resolve(basedir, file) });
     }
     
     if (!row.id) {
-        row.id = expose || file;
+        row.id = expose || row.file;
     }
     if (expose || !row.entry) {
         // Make this available to mdeps so that it can assign the value when it
@@ -180,10 +180,7 @@ Browserify.prototype.require = function (file, opts) {
         self._bpack.hasExports = true;
     }
     
-    if (row.entry) {
-        row.file = path.resolve(basedir, row.file);
-        row.order = self._entryOrder ++;
-    }
+    if (row.entry) row.order = self._entryOrder ++;
     
     if (opts.transform === false) row.transform = false;
     self.pipeline.write(row);

--- a/test/multi_entry_cross_require/a.js
+++ b/test/multi_entry_cross_require/a.js
@@ -1,0 +1,8 @@
+times ++;
+t.equal(times, 1);
+
+var b = require('./lib/b');
+t.equal(times, 2);
+
+b.foo();
+t.equal(times, 3);

--- a/test/multi_entry_cross_require/c.js
+++ b/test/multi_entry_cross_require/c.js
@@ -1,0 +1,7 @@
+times++;
+t.equal(times, 4);
+
+var b = require('./lib/b');
+b.foo();
+
+t.equal(times, 5);

--- a/test/multi_entry_cross_require/lib/b.js
+++ b/test/multi_entry_cross_require/lib/b.js
@@ -1,0 +1,5 @@
+times++;
+
+module.exports.foo = function() {
+  times++;
+};


### PR DESCRIPTION
Fixes https://github.com/substack/node-browserify/issues/1266. I broke it in https://github.com/substack/node-browserify/pull/1248. What was happening was that I was setting `row.file` too late, and `row.id` was not getting the full path. The example in  https://github.com/substack/node-browserify/issues/1266 would've worked via the CLI before https://github.com/substack/node-browserify/pull/1248, but not via the API. This PR fixes that.

@jmm I really want to merge the refactor of `b.require` from https://gist.github.com/zertosh/e66a3e96afc45228f02b (taking these changes into account). What tests do you think are missing before we can do it w/o fear of major breakage?