### PR TITLE
fix missing space in bin/args for browserField

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -20,7 +20,7 @@ module.exports = function (args, opts) {
         alias: {
             ig: [ 'insert-globals', 'fast' ],
             dg: [ 'detect-globals', 'detectGlobals', 'dg' ],
-            bf: [ 'browser-field', 'browserField ' ],
+            bf: [ 'browser-field', 'browserField' ],
             im: 'ignore-missing',
             it: 'ignore-transform',
             igv: 'insert-global-vars',


### PR DESCRIPTION
Fixes #1286: issue with `--no-browser-field` not setting the option correctly because of an extra space in the argument aliases.