### PR TITLE
define __dirname,__filename as documented for --bare, ...

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -64,6 +64,14 @@ module.exports = function (args, opts) {
         return entry;
     });
     
+    var insertGlobalVars;
+    if (argv.igv) {
+        insertGlobalVars = argv.igv.split(',').reduce(function (vars, x) {
+            vars[x] = insertGlobals.vars[x];
+            return vars;
+        }, {});
+    }
+    
     if (argv.node) {
         argv.bare = true;
         argv.browserField = false;
@@ -71,12 +79,15 @@ module.exports = function (args, opts) {
     if (argv.bare) {
         argv.builtins = false;
         argv.commondir = false;
-        argv.detectGlobals = false;
-        if (argv.igv === undefined) {
-            argv.igv = '__filename,__dirname';
-        }
+        if (!insertGlobalVars) insertGlobalVars = {};
+        Object.keys(insertGlobals.vars).forEach(function (x) {
+            insertGlobalVars[x] = undefined;
+        });
+        ['__dirname', '__filename'].forEach(function (x) {
+            insertGlobalVars[x] = insertGlobals.vars[x];
+        });
     }
-
+    
     var ignoreTransform = argv['ignore-transform'] || argv.it;
     var b = browserify(xtend({
         noParse: Array.isArray(argv.noParse) ? argv.noParse : [argv.noParse],
@@ -232,14 +243,6 @@ module.exports = function (args, opts) {
     if (argv.standalone === '') {
         error('--standalone requires an export name argument');
         return b;
-    }
-    
-    var insertGlobalVars;
-    if (argv.igv) {
-        insertGlobalVars = argv.igv.split(',').reduce(function (vars, x) {
-            vars[x] = insertGlobals.vars[x];
-            return vars;
-        }, {});
     }
     
     return b;

--- a/index.js
+++ b/index.js
@@ -552,8 +552,8 @@ Browserify.prototype._createDeps = function (opts) {
         }, opts.insertGlobalVars);
         
         if (opts.bundleExternal === false) {
-            delete vars.process;
-            delete vars.buffer;
+            vars.process = undefined;
+            vars.buffer = undefined;
         }
         
         return insertGlobals(file, xtend(opts, {

--- a/test/bare.js
+++ b/test/bare.js
@@ -37,3 +37,34 @@ test('bare', function (t) {
         t.equal(code, 0);
     });
 });
+
+test('bare inserts __filename,__dirname but not process,global,Buffer', function (t) {
+    t.plan(2);
+    
+    var ps = spawn(process.execPath, [
+        path.resolve(__dirname, '../bin/cmd.js'),
+        path.resolve(__dirname, 'bare/main.js'),
+        '--bare'
+    ]);
+    
+    ps.stdout.pipe(concat(function (body) {
+        vm.runInNewContext(body, {
+            console: {
+                log: function(msg) {
+                    t.same(msg, [
+                        path.join(__dirname, 'bare'),
+                        path.join(__dirname, 'bare/main.js'),
+                        'undefined',
+                        'undefined',
+                        'undefined'
+                    ]);
+                }
+            }
+        });
+    }));
+    ps.stdin.end();
+    
+    ps.on('exit', function (code) {
+        t.equal(code, 0);
+    });
+});

--- a/test/bare/main.js
+++ b/test/bare/main.js
@@ -1,0 +1,7 @@
+console.log([
+  __dirname,
+  __filename,
+  typeof process,
+  typeof global,
+  typeof Buffer
+]);

--- a/test/bundle_external_global.js
+++ b/test/bundle_external_global.js
@@ -18,7 +18,7 @@ test('bundle external global', function (t) {
             process: process
         });
         function log (msg) {
-            t.equal(typeof msg.nextTick, 'function');
+            t.equal(msg, process);
         }
     });
 });


### PR DESCRIPTION
... but don't define process,global,Buffer.

This fixes substack/covert#12

This might also be of interest to:
* substack/node-browserify#1287
* substack/node-browserify#1290
* substack/node-browserify#979