### PR TITLE
bump buffer to 3.4.3 to fix maximum call stack exceeded errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "browser-pack": "^5.0.0",
     "browser-resolve": "^1.7.1",
     "browserify-zlib": "~0.1.2",
-    "buffer": "^3.0.0",
+    "buffer": "^3.4.3",
     "builtins": "~0.0.3",
     "commondir": "0.0.1",
     "concat-stream": "~1.4.1",


### PR DESCRIPTION
Many modules are reporting `maximum call stack exceeded` errors (at least in Chrome) that were due to a bug in the `buffer` module.
eg:
- https://github.com/evanw/node-source-map-support/issues/95
- https://github.com/feross/buffer/pull/70

This PR simply bumps buffer to the 3.4.3 revision and has fixed the source maps problem as well as another problem I came across in auth0's lock module.

All tests pass with this bump