### PR TITLE
browserify adds the '.' in case you forget it (#649 fix)

### DIFF
--- a/bin/args.js
+++ b/bin/args.js
@@ -80,7 +80,13 @@ module.exports = function (args, opts) {
     var ignoreTransform = argv['ignore-transform'] || argv.it;
     var b = browserify(xtend({
         noParse: Array.isArray(argv.noParse) ? argv.noParse : [argv.noParse],
-        extensions: [].concat(argv.extension).filter(Boolean),
+        extensions: [].concat(argv.extension).filter(Boolean).map(function (extension) {
+            if (extension.charAt(0) != '.') { 
+                return '.' + extension;
+            } else {
+                return extension
+            }
+        }),
         ignoreTransform: [].concat(ignoreTransform).filter(Boolean),
         entries: entries,
         fullPaths: argv['full-paths'],


### PR DESCRIPTION
All the extension options will automatically have a `.` pretended to the argument, if one is not already present. Fixed this issue according to this [comment] (https://github.com/substack/node-browserify/issues/649#issuecomment-34950912)

Let me know how it looks! :smile: 