### PR TITLE
bump stream-http version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "glob": "^4.0.5",
     "has": "^1.0.0",
     "htmlescape": "^1.1.0",
-    "stream-http": "^1.2.0",
+    "stream-http": "^2.0.0",
     "https-browserify": "~0.0.0",
     "inherits": "~2.0.1",
     "insert-module-globals": "^6.4.1",


### PR DESCRIPTION
This version of stream-http omits reimplementations of es5 functions
for ie8. The suggested polyfills, or a full set like es5-shim, are
now needed to use `http` in ie8.