### PR TITLE
Only use entry files for standalone export

### DIFF
--- a/index.js
+++ b/index.js
@@ -712,7 +712,7 @@ Browserify.prototype._label = function (opts) {
             }
         });
         
-        if (row.entry || row.expose) {
+        if (row.entry) {
             self._bpack.standaloneModule = row.id;
         }
         this.push(row);

--- a/test/debug_standalone.js
+++ b/test/debug_standalone.js
@@ -41,15 +41,11 @@ test('debug standalone', function (t) {
     });
 });
 
-test('debug standalone exposed', function (t) {
+test('debug standalone entry', function (t) {
     t.plan(2);
-    
-    var stream = through();
-    stream.push('console.log(1+2)');
-    stream.push(null);
-    
+
     var b = browserify({ debug: true, standalone: 'xyz' });
-    b.require(__dirname + '/debug_standalone/x.js', { expose: 'xxx' });
+    b.add(__dirname + '/debug_standalone/x.js');
     b.bundle(function (err, buf) {
         var src = buf.toString('utf8');
         var last = src.split('\n').slice(-2)[0];
@@ -60,5 +56,25 @@ test('debug standalone exposed', function (t) {
         var c = { window: {} };
         vm.runInNewContext(src, c);
         t.equal(c.window.xyz, 555);
+    });
+});
+
+test('debug standalone exposed', function (t) {
+    t.plan(2);
+
+    var b = browserify({ debug: true, standalone: 'xyz' });
+    // No entry files so nothing to expose
+    b.require(__dirname + '/debug_standalone/x.js', { expose: 'xxx' });
+    b.bundle(function (err, buf) {
+        var src = buf.toString('utf8');
+        var last = src.split('\n').slice(-2)[0];
+        t.ok(
+            /\/\/# sourceMappingURL=data:application\/json;charset:utf-8;base64,[\w+\/=]+$/
+            .test(last)
+        );
+        var c = { window: {} };
+        t.throws(function() {
+          vm.runInNewContext(src, c);
+        });
     });
 });


### PR DESCRIPTION
If I want to to use `require('foo')` in my code, I do `browserify().require('./foo', {expose: 'foo'})`. Just because I do that, doesn't mean I want that to now be an entrypoint of my app, I just want it to be a library available internally.

Fixes #1390
Fixes #1120

This breaks backwards compatibility for people solely using `require()` (which I think is an error since there is not entry files). Change the one that was highest number to an `add()` and it will work as before.