### PR TITLE
Bumping labeled-stream-splicer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "inherits": "~2.0.1",
     "insert-module-globals": "^6.4.1",
     "isarray": "0.0.1",
-    "labeled-stream-splicer": "^1.0.0",
+    "labeled-stream-splicer": "^2.0.0",
     "module-deps": "^3.7.11",
     "os-browserify": "~0.1.1",
     "parents": "^1.0.1",


### PR DESCRIPTION
Eliminates dependency on obsolete `indexof@0.0.1` (deprecated by `component-indexof`) in outdated sub-depedency `stream-splicer@1.3.2`.