### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "glob": "^4.0.5",
     "has": "^1.0.0",
     "htmlescape": "^1.1.0",
-    "stream-http": "^1.2.0",
+    "stream-http": "^2.0.2",
     "https-browserify": "~0.0.0",
     "inherits": "~2.0.1",
     "insert-module-globals": "^6.4.1",


### PR DESCRIPTION
The outdated `stream-http@1.7.1` has a dependency on the  deprecated
`indexof@0.0.1` package. See also: https://github.com/substack/node-browserify/pull/1402