### PR TITLE
Remove unnecessary workaround to hide full path

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,9 +547,7 @@ Browserify.prototype._createDeps = function (opts) {
             }
         }
         
-        var vars = xtend({
-            process: function () { return "require('_process')" },
-        }, opts.insertGlobalVars);
+        var vars = xtend(opts.insertGlobalVars);
         
         if (opts.bundleExternal === false) {
             vars.process = undefined;

--- a/lib/builtins.js
+++ b/lib/builtins.js
@@ -35,4 +35,3 @@ exports.url = require.resolve('url/');
 exports.util = require.resolve('util/util.js');
 exports.vm = require.resolve('vm-browserify');
 exports.zlib = require.resolve('browserify-zlib');
-exports._process = require.resolve('process/browser');


### PR DESCRIPTION
This was previously added in 5fe121b to prevent the absolute path to the "process" module from exposed in the bundle.

Recently a [change landed in insert-module-globals][1] that prevents this from happening in the first place, thus this workaround is no longer needed.

[1]: https://github.com/substack/insert-module-globals/pull/54

This is technically a breaking change for those who are calling `require("_process")` directly (which should not happen as it was never advertised as a public api).

**There are currently failing tests** 

```
    not ok 2 - cwd directory visible
      ---
      found: 2675
      wanted: -1
      compare: ===
      at:
        file: test/leak.js
        line: 32
        column: 11
      source: |
        t.equal(src.indexOf(process.cwd()), -1, 'cwd directory visible');
      stack: >
        test/leak.js:32:11
        ...
```

This is because the test checks for the existence of process.cwd()` in the bundle, which exists because the basedir of the bundle is set to `/tmp/...` and the relative path from `/tmp/...` to where the process module is happens to include the `process.cwd()` substring in it: `../../../home/parshap/projects/node-browserify/node_modules/process/browser.js`.

I'm not sure what the right approach is here.

1. Is this ok, or we are allowing too much to be exposed in the odd case that the bundle basedir is in a completely different directory than where the browserify `node_modules` directory is?

1. If it's ok, how should the test be changed? Should this assertion be removed?

1. If it's not ok, should we add the same kind of workaround for `Buffer.isBuffer` (e.g., ass a `require("_is-buffer")` builtin)?