### PR TITLE
Dep round trip

### DIFF
--- a/index.js
+++ b/index.js
@@ -448,6 +448,7 @@ Browserify.prototype._createDeps = function (opts) {
         if (opts.filter && !opts.filter(id)) return false;
         if (self._external.indexOf(id) >= 0) return false;
         if (self._exclude.indexOf(id) >= 0) return false;
+        if (self._expose.hasOwnProperty(id)) return false;
         if (opts.bundleExternal === false && isExternalModule(id)) {
             return false;
         }

--- a/test/dep.js
+++ b/test/dep.js
@@ -23,3 +23,23 @@ test('dependency events', function (t) {
         return a.id < b.id ? -1 : 1;
     }
 });
+
+test('round-trip dependency events', function(t) {
+    var b = browserify(__dirname + '/entry/needs_three.js');
+    var cache = {};
+    b.on('dep', function(row) {
+        cache[row.file] = row;
+    });
+
+    b.require(__dirname + '/entry/three.js', { expose: 'three' });
+    b.bundle(function(err, src) {
+        var b2 = browserify(__dirname + '/entry/needs_three.js', { cache: cache });
+        b2.require(__dirname + '/entry/three.js', { expose: 'three' });
+
+        b2.bundle(function(err, src) {
+            t.ok(!err);
+            t.ok(src);
+            t.end();
+        });
+    });
+});


### PR DESCRIPTION
This fixes https://github.com/jsdf/browserify-incremental/issues/22, which arises because `dep` events come with a row that can't be fed back into the cache.  This happens in the case when you have a file that is both exposed and required under its exposed name in the same bundle (which seems like it ought to be valid, and works fine without setting the cache option).