### PR TITLE
Fix paths in example of multiple bundles

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -318,23 +318,23 @@ module.exports = function (s) { return s.toUpperCase() + '!' };
 ```
 
 ```
-$ browserify -r ./robot.js > static/common.js
-$ browserify -x ./robot.js beep.js > static/beep.js
-$ browserify -x ./robot.js boop.js > static/boop.js
+$ browserify -r ./robot.js > bundle/common.js
+$ browserify -x ./robot.js beep.js > bundle/beep.js
+$ browserify -x ./robot.js boop.js > bundle/boop.js
 ```
 
 Then on the beep page you can have:
 
 ``` html
-<script src="common.js"></script>
-<script src="beep.js"></script>
+<script src="bundle/common.js"></script>
+<script src="bundle/beep.js"></script>
 ```
 
 while the boop page can have:
 
 ``` html
-<script src="common.js"></script>
-<script src="boop.js"></script>
+<script src="bundle/common.js"></script>
+<script src="bundle/boop.js"></script>
 ```
 
 This approach using `-r` and `-x` works fine for a small number of split assets,


### PR DESCRIPTION
Also replaced dir name `static` with `bundle` to make it clear those are the bundle files generated by browserify, not the source files.
