### PR TITLE
Fix badly formed module paths on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,12 +115,14 @@ Browserify.prototype.require = function (file, opts) {
     var expose = opts.expose;
     if (file === expose && /^[\.]/.test(expose)) {
         expose = '/' + path.relative(basedir, expose);
+        expose = expose.replace(/\\/g, '/');
     }
     if (expose === undefined && this._options.exposeAll) {
         expose = true;
     }
     if (expose === true) {
         expose = '/' + path.relative(basedir, file);
+        expose = expose.replace(/\\/g, '/');
     }
     
     if (isStream(file)) {


### PR DESCRIPTION
This addresses the issue raised in #1358.

It ensures 'required' modules have the expected path, i.e. `require("/apps/Call")` instead of `require("/apps\\Call")`.