### PR TITLE
Added failing test: browserify still transforms symlinked modules

### DIFF
--- a/test/tr_symlink/b-module/ext.js
+++ b/test/tr_symlink/b-module/ext.js
@@ -1,0 +1,1 @@
+module.exports = 777;

--- a/test/tr_symlink/b-module/index.js
+++ b/test/tr_symlink/b-module/index.js
@@ -1,1 +1,2 @@
-module.exports = 777
+var ext = require('./ext');
+module.exports = ext;


### PR DESCRIPTION
This is a failing test showing that #1386 wasn't properly fixed.
The problem is that while symlinked modules containing a single file works, any subsequent relative requires made from that module are still being transformed, breaking any non-trivial example.

