### PR TITLE
Update module-deps to 4.0.3 (fixes upstream regression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "insert-module-globals": "^7.0.0",
     "isarray": "0.0.1",
     "labeled-stream-splicer": "^2.0.0",
-    "module-deps": "^4.0.2",
+    "module-deps": ">= 4.0.3 < 5",
     "os-browserify": "~0.1.1",
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",


### PR DESCRIPTION
See https://github.com/substack/module-deps/issues/105

I am hitting this regression in a library that browserify is a dependency of. I would like to ensure that the users of that library do not have an old version of module-deps installed. The only good way to do that is to add a version range in browserify's package configuration (`"module-deps": ">= 4.0.3 < 5"`); so that I can do the same in that library (e.g. `"browserify": ">= 12.0.3 < 13"`).