### PR TITLE
Update buffer to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "browser-pack": "^6.0.1",
     "browser-resolve": "^1.11.0",
     "browserify-zlib": "~0.1.2",
-    "buffer": "^3.4.3",
+    "buffer": "^3.6.0",
     "concat-stream": "~1.5.1",
     "console-browserify": "^1.1.0",
     "constants-browserify": "~1.0.0",


### PR DESCRIPTION
Resolves #1418 by using a newer version of buffer which fixes the root issue (feross/buffer#79).