### PR TITLE
buffer@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "browser-pack": "^6.0.1",
     "browser-resolve": "^1.11.0",
     "browserify-zlib": "~0.1.2",
-    "buffer": "^3.4.3",
+    "buffer": "^4.1.0",
     "concat-stream": "~1.5.1",
     "console-browserify": "^1.1.0",
     "constants-browserify": "~1.0.0",


### PR DESCRIPTION
Node.js removed the `buffer.toArrayBuffer()` API sometime during node 0.11. Users who rely on it will have code that doesn't work in node.js, which is unfortunate.

`feross/buffer` v4.0.0 removed `buffer.toArrayBuffer()` to have parity with node.js.

Going forward, users can just use `buffer.buffer` to get an `ArrayBuffer` since `Buffer` is just a subclass of `Uint8Array` in both node.js and the browser.

This is a breaking change, since we're removing a method from the buffer.

I'm only sending this PR now, since buffer v4.1.0 has a 30% performance increase for lots of the buffer methods and I want users to have that :+1: 