### PR TITLE
package.json: use `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,5 +88,9 @@
   "scripts": {
     "test": "tap test/*.js"
   },
+  "files": [
+    "lib",
+    "bin"
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
This makes the install faster, by not installing `test` and `example` (130KB, 428 files).
`index.js`, `LICENSE`, `changelog.markdown`, `package.json` & `readme.markdown` are automatically included, see https://docs.npmjs.com/files/package.json#files and https://github.com/feross/buffer/pull/98.