### PR TITLE
Demonstrate bug with external bundles that are already complete

### DIFF
--- a/test/external_shim.js
+++ b/test/external_shim.js
@@ -25,3 +25,27 @@ test('requiring a shimmed module name from an external bundle', function (t) {
         });
     });
 });
+
+test('requiring a shimmed module name from an external bundle (late creation of second bundle)', function (t) {
+    var b1 = browserify();
+    var b2 = browserify();
+
+    b1.require(__dirname + '/external_shim/bundle1.js', { expose: 'bundle1' });
+
+    b1.bundle(function (err, src1) {
+        b2.external(b1);
+        b2.require(__dirname + '/external_shim/bundle2.js', { expose: 'bundle2' });
+        b2.bundle(function (err, src2) {
+            t.plan(1);
+
+            var c = {
+                console: console,
+                setTimeout: setTimeout,
+                clearTimeout: clearTimeout
+            };
+            vm.runInNewContext(src1 + src2, c);
+
+            t.ok(c.require('bundle1').shim === c.require('bundle2').shim);
+        });
+    });
+});


### PR DESCRIPTION
See the new test (it is *very* similar to the one above).

If you try do: 

```js
var bundle1 = browserify().stuff().bundle();

// and then after bundle1 completes:
var bundle2 = browserify().external(bundle1)
```

It won't work. 

It would be handy to keep bundles around.