### PR TITLE
Replace \\ with / in relative external paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,8 +253,10 @@ Browserify.prototype.external = function (file, opts) {
     
     if (!opts) opts = {};
     var basedir = defined(opts.basedir, process.cwd());
+    var relativePath = '/' + path.relative(basedir, file);
+    relativePath = relativePath.replace(/\\/g, '/');
     this._external.push(file);
-    this._external.push('/' + path.relative(basedir, file));
+    this._external.push('/' + relativePath);
     return this;
 };
 


### PR DESCRIPTION
Currently files required from other bundles imported like follows in Windows:
```
  bundler.external(['./assets/Master.js']);
```
will produce require calls as follows in the compiled file:
```
  var Master = require('/assets\\Master.js');
```
which will naturally fail. This fix replaces the double slashes with a single slash, like it's done in `Browserify.prototype.require`