### PR TITLE
Update glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "domain-browser": "~1.1.0",
     "duplexer2": "~0.1.2",
     "events": "~1.1.0",
-    "glob": "^5.0.15",
+    "glob": "^7.0.5",
     "has": "^1.0.0",
     "htmlescape": "^1.1.0",
     "https-browserify": "~0.0.0",


### PR DESCRIPTION
Currently installing `browserify` gives a warning:

```
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

This PR updates the `glob` dependency to the most recent version which uses an updated `minimatch` version as well.

I ran the tests after the change and they all still pass.