### PR TITLE
update tests to use Buffer.from

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+  console.log(new Buffer("ABC"))
+},{}]},{},[1]);

--- a/test/bare.js
+++ b/test/bare.js
@@ -16,13 +16,17 @@ test('bare', function (t) {
     ]);
     ps.stdout.pipe(concat(function (body) {
         vm.runInNewContext(body, {
-            Buffer: function (s) { return s.toLowerCase() },
+            Buffer: {
+              from: function (s) { return s.toLowerCase() }
+            },
             console: {
                 log: function (msg) { t.equal(msg, 'abc') }
             }
         });
         vm.runInNewContext(body, {
-            Buffer: Buffer,
+            Buffer: {
+              from: Buffer.from
+            },
             console: {
                 log: function (msg) {
                     t.ok(Buffer.isBuffer(msg));
@@ -31,7 +35,7 @@ test('bare', function (t) {
             }
         });
     }));
-    ps.stdin.end('console.log(Buffer("ABC"))');
+    ps.stdin.end('console.log(Buffer.from("ABC"))');
     
     ps.on('exit', function (code) {
         t.equal(code, 0);

--- a/test/bare_shebang.js
+++ b/test/bare_shebang.js
@@ -14,13 +14,17 @@ test('bare shebang', function (t) {
     ps.stderr.pipe(process.stderr);
     ps.stdout.pipe(concat(function (body) {
         vm.runInNewContext(body, {
-            Buffer: function (s) { return s.toLowerCase() },
+            Buffer: {
+              from: function (s) { return s.toLowerCase() }
+            },
             console: {
                 log: function (msg) { t.equal(msg, 'woo') }
             }
         });
         vm.runInNewContext(body, {
-            Buffer: Buffer,
+            Buffer: {
+              from: Buffer.from
+            },
             console: {
                 log: function (msg) {
                     t.ok(Buffer.isBuffer(msg));
@@ -29,7 +33,7 @@ test('bare shebang', function (t) {
             }
         });
     }));
-    ps.stdin.end('#!/usr/bin/env node\nconsole.log(Buffer("WOO"))');
+    ps.stdin.end('#!/usr/bin/env node\nconsole.log(Buffer.from("WOO"))');
     
     ps.on('exit', function (code) {
         t.equal(code, 0);


### PR DESCRIPTION
Using Buffer without new will soon stop working. It will throw
A deprecation warning in Node v7. This commit modifies the tests
in `test/bare.js` and `test/bare_shebang.js` to use the
`Buffer.from` interface instead. It is a drop in replacement for
Buffer that is supported by Node v4 / v6 and Browserify's Buffer
implementation

For the browserify test suite to pass on Node v7 we will need
to land this commit as well as the two below PR's
- https://github.com/substack/browser-pack/pull/75
- https://github.com/maxogden/concat-stream/pull/48
