### PR TITLE
Allow configuring transformKey option for module-deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -434,7 +434,7 @@ Browserify.prototype._createDeps = function (opts) {
     self._extensions = mopts.extensions;
 
     mopts.transform = [];
-    mopts.transformKey = [ 'browserify', 'transform' ];
+    mopts.transformKey = defined(opts.transformKey, [ 'browserify', 'transform' ]);
     mopts.postFilter = function (id, file, pkg) {
         if (opts.postFilter && !opts.postFilter(id, file, pkg)) return false;
         if (self._external.indexOf(file) >= 0) return false;

--- a/test/ignore_transform_key.js
+++ b/test/ignore_transform_key.js
@@ -1,0 +1,17 @@
+var browserify = require('../');
+var test = require('tap').test;
+var vm = require('vm');
+
+test('ignore transform', function(t) {
+  t.plan(1);
+
+  var b = browserify({
+    transformKey: false
+  });
+  b.add(__dirname + '/ignore_transform_key/main.js');
+
+  b.bundle(function(err, src) {
+    if (err) t.fail(err);
+    vm.runInNewContext(src, {t: t});
+  });
+});

--- a/test/ignore_transform_key/main.js
+++ b/test/ignore_transform_key/main.js
@@ -1,0 +1,3 @@
+var a = require('a');
+
+t.equal(a, 'good');

--- a/test/ignore_transform_key/node_modules/a/index.js
+++ b/test/ignore_transform_key/node_modules/a/index.js
@@ -1,0 +1,1 @@
+module.exports = 'good';

--- a/test/ignore_transform_key/node_modules/a/package.json
+++ b/test/ignore_transform_key/node_modules/a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "private": true,
+  "browserify": {
+    "transform": [
+      "evil-transform"
+    ]
+  }
+}

--- a/test/ignore_transform_key/node_modules/evil-transform/index.js
+++ b/test/ignore_transform_key/node_modules/evil-transform/index.js
@@ -1,0 +1,12 @@
+const through2 = require('through2');
+
+module.exports = function() {
+
+  return through2.obj(function(row, enc, next) {
+      return next();
+    },
+    function(next) {
+      next(null, "module.exports = 'evil';");
+    }
+  )
+};

--- a/test/ignore_transform_key/node_modules/evil-transform/package.json
+++ b/test/ignore_transform_key/node_modules/evil-transform/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "evil-transform",
+  "version": "1.0.0",
+  "private": true
+}


### PR DESCRIPTION
module-deps supports specifiying the transformKey to use for looking up the transforms defined in package.json of dependencies. In some cases it is desirable to suppress this behaviour. This PR allows you to specifiy this via browserify options.