### PR TITLE
Update 'buffer' to v5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "browser-pack": "^6.0.1",
     "browser-resolve": "^1.11.0",
     "browserify-zlib": "~0.1.2",
-    "buffer": "^4.1.0",
+    "buffer": "^5.0.2",
     "cached-path-relative": "^1.0.0",
     "concat-stream": "~1.5.1",
     "console-browserify": "^1.1.0",

--- a/test/double_buffer.js
+++ b/test/double_buffer.js
@@ -9,6 +9,6 @@ test('double buffer', function (t) {
     b.require('buffer');
     b.bundle(function (err, src) {
         if (err) return t.fail(err);
-        vm.runInNewContext(src, { t: t });
+        vm.runInNewContext(src, { t: t, Uint8Array: Uint8Array });
     });
 });

--- a/test/global.js
+++ b/test/global.js
@@ -26,7 +26,7 @@ test('__filename and __dirname with insertGlobals: true', function (t) {
     });
     b.require(__dirname + '/global/filename.js', { expose: 'x' });
     b.bundle(function (err, src) {
-        var c = {};
+        var c = { Uint8Array: Uint8Array };
         c.self = c;
         vm.runInNewContext(src, c);
         var x = c.require('x');

--- a/test/leak.js
+++ b/test/leak.js
@@ -52,6 +52,6 @@ test('leaking information about system paths (Buffer)', function (t) {
         t.equal(src.indexOf(dirstring), -1, 'temp directory visible');
         t.equal(src.indexOf(process.cwd()), -1, 'cwd directory visible');
         t.equal(src.indexOf('/home'), -1, 'home directory visible');
-        vm.runInNewContext(src, { t: t, setTimeout: setTimeout });
+        vm.runInNewContext(src, { t: t, setTimeout: setTimeout, Uint8Array: Uint8Array });
     });
 });


### PR DESCRIPTION
### Browser support

buffer v5.x drops support for IE8-10.

This allows us to remove the `Object` implementation and rely on a single
fast implementation based on Typed Arrays, greatly simplifying the maintanence of the
buffer package.

Typed arrays are supported by 97.08% of the U.S. browser market and 92.02% of the
global browser market. Source: http://caniuse.com/#search=typed This number 
continues to increase at a steady rate each month.

If IE8-10 support is critical to your web app, you can continue to rely on
browserify v13.

### Bundle size

This change shrinks the size of buffer modestly.

55.1kb -> 52.1kb (full size, with comments)
7.0kb -> 6.7kb (minified, gzipped)

### Bug fixes

buffer v5.x contains several important fixes including:

- https://github.com/feross/buffer/commit/3639a98a97888477d1bc6b335fb27b48b550a751
- https://github.com/feross/buffer/commit/4e5c4526f4c29201fa833a89d8fe2bf15ebb18e5
- https://github.com/feross/buffer/commit/99491d2f16d6f20940dd86ed2cb6e8629181723e

### Semver

This should be released as semver major.