### PR TITLE
Fix interaction between fullPaths and external

### DIFF
--- a/index.js
+++ b/index.js
@@ -697,11 +697,12 @@ Browserify.prototype._label = function (opts) {
 
             var afile = path.resolve(path.dirname(row.file), key);
             var rfile = '/' + relativePath(basedir, afile);
+            var exposefile = opts.fullPaths ? afile : rfile;
             if (self._external.indexOf(rfile) >= 0) {
-                row.deps[key] = rfile;
+                row.deps[key] = exposefile;
             }
             if (self._external.indexOf(afile) >= 0) {
-                row.deps[key] = rfile;
+                row.deps[key] = exposefile;
             }
             if (self._external.indexOf(key) >= 0) {
                 row.deps[key] = key;
@@ -711,7 +712,7 @@ Browserify.prototype._label = function (opts) {
             for (var i = 0; i < self._extensions.length; i++) {
                 var ex = self._extensions[i];
                 if (self._external.indexOf(rfile + ex) >= 0) {
-                    row.deps[key] = rfile + ex;
+                    row.deps[key] = exposefile + ex;
                     break;
                 }
             }

--- a/test/full_paths.js
+++ b/test/full_paths.js
@@ -56,3 +56,28 @@ test('fullPaths enabled, with custom exposed dependency name', function (t) {
         });
     });
 });
+
+test('fullPaths enabled, with external path', function (t) {
+    t.plan(3);
+
+    var b = browserify({
+        entries: [__dirname + '/external/main.js'],
+        fullPaths: true
+    });
+
+    b.external('freelist');
+    var absxpath = __dirname + '/external/x.js';
+    b.external(absxpath);
+
+    b.bundle(function (err, src) {
+        if (err) return t.fail(err);
+        vm.runInNewContext(
+            'function require (x) {'
+            + 'if (x==="freelist") return function (n) { return n + 1000 };'
+            + 'if (x==="' + absxpath + '") return function (n) { t.ok(true); return n + 1010 }'
+            + '}'
+            + src,
+            { t: t }
+        );
+    });
+});


### PR DESCRIPTION
Consider the case where you are splitting bundles with your own code, not in node_modules. You have bundle 1, which has the `require` calls, and you also have bundle 2, which makes the same `external` calls. Assume the default expose names and relative require arguments with no aliasing magic.

When `fullPaths` is false in both, this works fine if you are careful with setting `basedir`. When `fullPaths` is true in both, bundle 1 will expose absolute paths but bundle 2's external IDs are the ones relative to the basedir. As #1534 notes, currently you can't get bundle 2 to look for the absolute paths, so if you want to use an ecosystem tool requiring `fullPaths`, you're stuck.

(The potential workaround of specifying `expose` yourself may run into #1629, though I didn't check carefully. For that issue, I think the suggested fix works, i.e. patch deps-sort in the obvious way, but that's separate from this PR.)

This PR makes it so that if you compile bundle 2 with `fullPaths` true, the external IDs are absolute paths. So `fullPaths` is now usable. One minor disadvantage: consistent `fullPaths` settings across bundles is now a requirement. If someone has it where bundle 1 is compiled with `fullPaths` false and bundle 2 is compiled with `fullPaths` true, their setup works now and my PR will break it.