### PR TITLE
Version upgrade of module-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "inherits": "~2.0.1",
     "insert-module-globals": "^7.0.0",
     "labeled-stream-splicer": "^2.0.0",
-    "module-deps": "^4.0.8",
+    "module-deps": "^4.1.0",
     "os-browserify": "~0.1.1",
     "parents": "^1.0.1",
     "path-browserify": "~0.0.0",


### PR DESCRIPTION
Recently [module-deps@4.1.0](https://github.com/substack/module-deps/releases/tag/4.1.0) was published with a new cache API. This PR updates the dependency and enables it for browserify 😍. 

_General side question:_
_Wouldn't it be better to change the dependency of `module-deps` and `browser-pack` to a `>4.1.0` and `>6.0.0` since we are respecting the semver and pass all configuration to the packages anyways:_

> All other options are forwarded along to module-deps and browser-pack directly.