### PR TITLE
update https-browserify to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "glob": "^7.1.0",
     "has": "^1.0.0",
     "htmlescape": "^1.1.0",
-    "https-browserify": "~0.0.0",
+    "https-browserify": "^1.0.0",
     "inherits": "~2.0.1",
     "insert-module-globals": "^7.0.0",
     "labeled-stream-splicer": "^2.0.0",


### PR DESCRIPTION
See: https://github.com/substack/https-browserify/commit/7295a7cf5c0928f8fd7e24ed8aae17801726e88b

Match Node.js behavior exactly

- Remove unused 'scheme' property
- Throw exception if non-https URL is passed in
- Support string URL arguments
- First argument is always required, so remove code that sets default
object if params doesn't exist