### PR TITLE
Document ignoreMissing option for browserify() (closes #1595)

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -460,6 +460,9 @@ When `opts.detectGlobals` is true, scan all files for `process`, `global`,
 `__filename`, and `__dirname`, defining as necessary. With this option npm
 modules are more likely to work but bundling takes longer. Default true.
 
+When `opts.ignoreMissing` is true, ignore `require()` statements that don't
+resolve to anything.
+
 When `opts.debug` is true, add a source map inline to the end of the bundle.
 This makes debugging easier because you can see all the original files if
 you are in a modern enough browser.


### PR DESCRIPTION
The option is used by the CLI but was previously not documented in the README.