### PR TITLE
Make custom extension name has higher priority.

### DIFF
--- a/index.js
+++ b/index.js
@@ -430,7 +430,7 @@ Browserify.prototype._createDeps = function (opts) {
     // Let mdeps populate these values since it will be resolving file paths
     // anyway.
     mopts.expose = this._expose;
-    mopts.extensions = [ '.js', '.json' ].concat(mopts.extensions || []);
+    mopts.extensions = (mopts.extensions || []).concat([ '.js', '.json' ]);
     self._extensions = mopts.extensions;
 
     mopts.transform = [];


### PR DESCRIPTION
I use browserify to bundle a library that mixes react and react-native, it's [antd-mobile](https://github.com/ant-design/ant-design-mobile).  this library use `.web.js` extension name for web component, browserify bundles it will failed even I specified custom extension.